### PR TITLE
Remove gray background from editor blockquotes to fix indent highlight

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5017,7 +5017,7 @@
             padding: 12px 20px;
             margin: 15px 0;
             color: var(--text-secondary);
-            background: var(--surface-bg);
+            background: transparent;
             border-radius: 0 10px 10px 0;
         }
 
@@ -13263,7 +13263,6 @@ body.icon-fallback-active .quick-app-btn i[class*="fa-"] {
     font-size: 0.95rem;
     min-width: 1.1em;
 }
-
 
 
 


### PR DESCRIPTION
### Motivation
- Indented content in the notes editor was showing an unwanted gray background inside blockquotes, creating a distracting global highlight when users indent content.

### Description
- Updated `.editor blockquote` in `styles.css` to change `background: var(--surface-bg)` to `background: transparent` to remove the gray fill while keeping border, padding, margin, color, and radius intact.
- No JavaScript logic or layout structure was modified.

### Testing
- Ran `npm run build`, which completed successfully.
- Launched the dev server and captured a browser automation screenshot (`artifacts/blockquote-indent-fix.png`) confirming the blockquote no longer displays the gray background.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73d8fea2c8331a94e550ca63fca3d)