### PR TITLE
Remove focus mode/focus reader, fix notes tab dash, and improve top-nav responsiveness

### DIFF
--- a/NoteflowAtelier.html
+++ b/NoteflowAtelier.html
@@ -1170,10 +1170,6 @@
                 </div>
                 <!-- Linked tasks feature removed -->
                 <div class="editor" id="editor" contenteditable="true" placeholder="Start typing..."></div>
-                <div id="focusReaderOverlay" class="focus-reader-overlay" hidden>
-                    <div id="focusReaderText" class="focus-reader-text"></div>
-                    <div class="settings-help" style="text-align:center;">Press Space to advance</div>
-                </div>
             </div>
 
             <!-- Status Bar removed - save indicator moved to bottom save bar (taskbar) -->
@@ -2028,20 +2024,6 @@
                                     <input type="checkbox" id="quickAppsToggle">
                                     <span>Enable Spotify/ChatGPT popup buttons</span>
                                 </label>
-                            </div>
-                            <div class="settings-row">
-                                <label class="settings-toggle">
-                                    <input type="checkbox" id="focusModeToggle">
-                                    <span>Focus mode (hide non-essential floating UI)</span>
-                                </label>
-                            </div>
-                            <div class="settings-row">
-                                <span>Focus reader words shown</span>
-                                <input type="number" min="1" max="15" step="1" class="modal-input" id="focusReaderVisibleWords" style="max-width:120px; margin:0;">
-                            </div>
-                            <div class="settings-row">
-                                <span>Focus reader highlighted words</span>
-                                <input type="number" min="1" max="5" step="1" class="modal-input" id="focusReaderHighlightWords" style="max-width:120px; margin:0;">
                             </div>
                             <div class="settings-row">
                                 <span>Temporary page expiry (hours)</span>
@@ -4392,17 +4374,6 @@
 
         .view { padding-bottom: 8px !important; }
         #view-notes .editor-container { padding-bottom: 8px !important; }
-
-        body.focus-mode .quick-app-launchers,
-        body.focus-mode .today-stats-strip,
-        body.focus-mode .today-panel-habits,
-        body.focus-mode .chatbot-btn,
-        body.focus-mode .chatbot-panel,
-        body.focus-mode .chatbot-info,
-        body.focus-mode .storage-options,
-        body.focus-mode .theme-switcher-btn {
-            display: none !important;
-        }
 
         @media (max-width: 1024px) {
             .view-more {

--- a/app.js
+++ b/app.js
@@ -1650,9 +1650,6 @@ function populateProgressDashboard() {
                     theme: 'default',
                     motionEnabled: true,
                     quickAppLaunchersEnabled: false,
-                    focusModeEnabled: false,
-                    focusReaderVisibleWords: 5,
-                    focusReaderHighlightWords: 1,
                     temporaryPageExpiryHours: 24,
                     sidebarCollapsed: false,
                     enabledViews: getDefaultEnabledViews(),
@@ -2563,17 +2560,6 @@ function populateProgressDashboard() {
             }, true);
 
             document.addEventListener('keydown', (event) => {
-                // Spacebar in focus reader
-                if (event.code === 'Space' && appSettings && appSettings.focusModeEnabled && activeView === 'notes') {
-                    const editor = document.getElementById('editor');
-                    const sel = window.getSelection();
-                    const insideEditor = sel && sel.anchorNode && editor && editor.contains(sel.anchorNode);
-                    if (!insideEditor) {
-                        event.preventDefault();
-                        advanceFocusReader();
-                        return;
-                    }
-                }
                 if (!activeCustomColorPicker) return;
                 if (event.key !== 'Escape') return;
                 event.preventDefault();
@@ -9201,22 +9187,6 @@ function populateProgressDashboard() {
             });
 
             syncFeatureSelectionControls();
-            const focusReaderVisibleWords = document.getElementById('focusReaderVisibleWords');
-            if (focusReaderVisibleWords) {
-                focusReaderVisibleWords.addEventListener('change', () => {
-                    appSettings.focusReaderVisibleWords = Math.max(1, Math.min(15, Math.floor(Number(focusReaderVisibleWords.value) || 5)));
-                    persistAppData();
-                    renderFocusReader();
-                });
-            }
-            const focusReaderHighlightWords = document.getElementById('focusReaderHighlightWords');
-            if (focusReaderHighlightWords) {
-                focusReaderHighlightWords.addEventListener('change', () => {
-                    appSettings.focusReaderHighlightWords = Math.max(1, Math.min(5, Math.floor(Number(focusReaderHighlightWords.value) || 1)));
-                    persistAppData();
-                    renderFocusReader();
-                });
-            }
             const tempPageExpiryHours = document.getElementById('tempPageExpiryHours');
             if (tempPageExpiryHours) {
                 tempPageExpiryHours.addEventListener('change', () => {
@@ -9308,7 +9278,7 @@ function populateProgressDashboard() {
                 const pct = getTaskCompletionForPage(currentPageId);
                 const badge = document.createElement('span');
                 badge.className = 'view-tab-progress';
-                badge.textContent = pct === null ? '—' : `${pct}%`;
+                badge.textContent = pct === null ? '' : `${pct}%`;
                 tab.appendChild(badge);
             });
         }
@@ -9403,18 +9373,9 @@ function populateProgressDashboard() {
             if (quickAppsToggle) {
                 quickAppsToggle.checked = !!(appSettings && appSettings.quickAppLaunchersEnabled);
             }
-            const focusModeToggle = document.getElementById('focusModeToggle');
-            if (focusModeToggle) {
-                focusModeToggle.checked = !!(appSettings && appSettings.focusModeEnabled);
-            }
-            const visibleWordsInput = document.getElementById('focusReaderVisibleWords');
-            if (visibleWordsInput) visibleWordsInput.value = String(appSettings?.focusReaderVisibleWords || 5);
-            const highlightWordsInput = document.getElementById('focusReaderHighlightWords');
-            if (highlightWordsInput) highlightWordsInput.value = String(appSettings?.focusReaderHighlightWords || 1);
             const tempExpiryInput = document.getElementById('tempPageExpiryHours');
             if (tempExpiryInput) tempExpiryInput.value = String(appSettings?.temporaryPageExpiryHours || 24);
             applyQuickAppLaunchersVisibility();
-            applyFocusModeState();
             const taskOrderStrategySelect = document.getElementById('taskOrderStrategySelect');
             if (taskOrderStrategySelect) {
                 taskOrderStrategySelect.value = getTaskOrderStrategy();
@@ -9441,54 +9402,6 @@ function populateProgressDashboard() {
             if (!launchers) return;
             const enabled = !!(appSettings && appSettings.quickAppLaunchersEnabled);
             launchers.style.display = enabled ? 'inline-flex' : 'none';
-        }
-
-        let focusReaderState = { words: [], index: 0 };
-
-        function tokenizeEditorWords() {
-            const editor = document.getElementById('editor');
-            const text = editor ? String(editor.innerText || '').trim() : '';
-            return text ? text.split(/\s+/).filter(Boolean) : [];
-        }
-
-        function renderFocusReader() {
-            const overlay = document.getElementById('focusReaderOverlay');
-            const textEl = document.getElementById('focusReaderText');
-            if (!overlay || !textEl) return;
-            const enabled = !!(appSettings && appSettings.focusModeEnabled);
-            overlay.hidden = !enabled;
-            if (!enabled) return;
-            focusReaderState.words = tokenizeEditorWords();
-            const visible = Math.max(1, Number(appSettings?.focusReaderVisibleWords || 5));
-            const highlight = Math.max(1, Math.min(visible, Number(appSettings?.focusReaderHighlightWords || 1)));
-            const idx = Math.max(0, Math.min(focusReaderState.index, Math.max(0, focusReaderState.words.length - 1)));
-            focusReaderState.index = idx;
-            const half = Math.floor(visible / 2);
-            let start = Math.max(0, idx - half);
-            let end = Math.min(focusReaderState.words.length, start + visible);
-            start = Math.max(0, end - visible);
-            const highlightStart = Math.max(start, idx - Math.floor(highlight / 2));
-            const highlightEnd = Math.min(end, highlightStart + highlight);
-            const seg = focusReaderState.words.slice(start, end).map((w, i) => {
-                const absolute = start + i;
-                const cls = absolute >= highlightStart && absolute < highlightEnd ? 'focus-word-active' : '';
-                return `<span class="${cls}">${escapeHtml(w)}</span>`;
-            });
-            textEl.innerHTML = seg.join(' ');
-        }
-
-        function advanceFocusReader() {
-            if (!focusReaderState.words.length) focusReaderState.words = tokenizeEditorWords();
-            if (!focusReaderState.words.length) return;
-            focusReaderState.index = Math.min(focusReaderState.words.length - 1, focusReaderState.index + 1);
-            renderFocusReader();
-        }
-
-        function applyFocusModeState() {
-            const enabled = !!(appSettings && appSettings.focusModeEnabled);
-            document.body.classList.toggle('focus-mode', enabled);
-            if (enabled) closeMoreViewsMenu();
-            renderFocusReader();
         }
 
         function syncTutorialSettingsControls() {
@@ -9729,17 +9642,6 @@ function populateProgressDashboard() {
             });
 
             document.addEventListener('keydown', (event) => {
-                // Spacebar in focus reader
-                if (event.code === 'Space' && appSettings && appSettings.focusModeEnabled && activeView === 'notes') {
-                    const editor = document.getElementById('editor');
-                    const sel = window.getSelection();
-                    const insideEditor = sel && sel.anchorNode && editor && editor.contains(sel.anchorNode);
-                    if (!insideEditor) {
-                        event.preventDefault();
-                        advanceFocusReader();
-                        return;
-                    }
-                }
                 const key = String(event.key || '').toLowerCase();
                 if ((event.ctrlKey || event.metaKey) && key === 'k') {
                     event.preventDefault();
@@ -10243,17 +10145,6 @@ function populateProgressDashboard() {
             }, true);
 
             document.addEventListener('keydown', (event) => {
-                // Spacebar in focus reader
-                if (event.code === 'Space' && appSettings && appSettings.focusModeEnabled && activeView === 'notes') {
-                    const editor = document.getElementById('editor');
-                    const sel = window.getSelection();
-                    const insideEditor = sel && sel.anchorNode && editor && editor.contains(sel.anchorNode);
-                    if (!insideEditor) {
-                        event.preventDefault();
-                        advanceFocusReader();
-                        return;
-                    }
-                }
                 if (!tutorialState.active) return;
                 if (event.key === 'Escape') {
                     event.preventDefault();
@@ -10302,17 +10193,6 @@ function populateProgressDashboard() {
                     }
                 });
                 document.addEventListener('keydown', (event) => {
-                // Spacebar in focus reader
-                if (event.code === 'Space' && appSettings && appSettings.focusModeEnabled && activeView === 'notes') {
-                    const editor = document.getElementById('editor');
-                    const sel = window.getSelection();
-                    const insideEditor = sel && sel.anchorNode && editor && editor.contains(sel.anchorNode);
-                    if (!insideEditor) {
-                        event.preventDefault();
-                        advanceFocusReader();
-                        return;
-                    }
-                }
                     if (event.key === 'Escape') closeMoreViewsMenu();
                 });
             }
@@ -10517,17 +10397,6 @@ function populateProgressDashboard() {
                     applyQuickAppLaunchersVisibility();
                 });
             }
-            const focusModeToggle = document.getElementById('focusModeToggle');
-            if (focusModeToggle) {
-                focusModeToggle.addEventListener('change', () => {
-                    if (appSettings) {
-                        appSettings.focusModeEnabled = !!focusModeToggle.checked;
-                        persistAppData();
-                    }
-                    applyFocusModeState();
-                });
-            }
-
             document.querySelectorAll('.feature-toggle-input[data-feature-view]').forEach(toggle => {
                 if (toggle.dataset.bound === 'true') return;
                 toggle.dataset.bound = 'true';
@@ -12353,7 +12222,6 @@ function populateProgressDashboard() {
   <li>Font family, size, line-height.</li>
   <li>Animations toggle and reduce motion.</li>
   <li>Quick apps toggle (Spotify/ChatGPT launchers).</li>
-  <li>Focus mode toggle (hide non-essential floating UI).</li>
   <li>Feature tab visibility controls in Settings.</li>
 </ul>
 <p><button type="button" class="help-anchor-btn help-anchor-top-btn" data-editor-anchor="top">Back to top</button></p>
@@ -19969,7 +19837,6 @@ function initTimeline() {
         }
     }, 60000);
 }
-
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -12830,7 +12830,7 @@ body[data-theme-key="dark"] .pages-list .page-item.active > i {
     border: 1px solid transparent;
 }
 
-/* 2026 UI refresh: simplified nav, utility dock, and focus mode */
+/* 2026 UI refresh: simplified nav and utility dock */
 .top-nav,
 .tabs-shell,
 .view-tabs {
@@ -13076,21 +13076,6 @@ body[data-theme-key="dark"] .pages-list .page-item.active > i {
     bottom: 164px !important;
 }
 
-body.focus-mode .quick-app-launchers,
-body.focus-mode .today-stats-strip,
-body.focus-mode .today-panel-habits,
-body.focus-mode .chatbot-btn,
-body.focus-mode .chatbot-panel,
-body.focus-mode .chatbot-info,
-body.focus-mode .storage-options,
-body.focus-mode .theme-switcher-btn {
-    display: none !important;
-}
-
-body.focus-mode #view-notes .editor-container {
-    padding-bottom: 24px !important;
-}
-
 .view { padding-bottom: 8px !important; }
 #view-notes .editor-container { padding-bottom: 8px !important; }
 
@@ -13287,25 +13272,6 @@ body.icon-fallback-active .quick-app-btn i[class*="fa-"] {
     text-decoration-color: currentColor;
 }
 
-.focus-reader-overlay {
-    margin-top: 12px;
-    padding: 14px;
-    border: 1px solid var(--surface-border);
-    border-radius: 10px;
-    background: var(--surface-bg);
-}
-
-.focus-reader-text {
-    text-align: center;
-    font-size: 1.1rem;
-    line-height: 1.8;
-}
-
-.focus-word-active {
-    color: var(--accent);
-    font-weight: 700;
-}
-
 .view-tab-progress {
     margin-left: 6px;
     font-size: 11px;
@@ -13314,4 +13280,51 @@ body.icon-fallback-active .quick-app-btn i[class*="fa-"] {
 
 .page-item.temp-page .page-title {
     opacity: 0.85;
+}
+
+
+/* Responsive stability fixes */
+.top-nav {
+    width: calc(100% - 40px);
+    max-width: 100%;
+}
+
+.nav-left,
+.tabs-shell {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.view-tabs {
+    max-width: 100%;
+    min-width: 0;
+}
+
+.nav-right {
+    min-width: 0;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.global-search {
+    min-width: 0;
+    width: min(320px, 100%);
+}
+
+@media (max-width: 1200px) {
+    .top-nav {
+        flex-wrap: wrap;
+        align-items: stretch;
+    }
+
+    .nav-right {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .global-search {
+        flex: 1 1 260px;
+        width: 100%;
+    }
 }


### PR DESCRIPTION
### Motivation
- Remove the Focus Mode / Focus Reader UI and runtime behavior entirely so there are no UI controls, keyboard handlers, or settings left for this feature. 
- Stop showing the stray dash on the Notes tab when there is no completion percentage. 
- Improve top navigation, tabs, and search layout so the site scales and wraps correctly across viewport sizes.

### Description
- Deleted Focus Reader overlay and Focus Mode controls from `NoteflowAtelier.html` and removed the Settings inputs for them. 
- Stripped Focus Mode / Focus Reader code paths and listeners from `app.js`, removed default focus settings, and eliminated all keyboard handlers specific to the feature. 
- Changed notes tab badge rendering to use an empty string when no percentage exists (replaced `—` with `''`) to remove the random dash. 
- Removed focus-mode CSS rules and focus-reader styles from `styles.css`, and added responsive nav safety rules to make `.top-nav`, `.view-tabs`, `.nav-left`, and `.nav-right` wrap/scale more reliably. 
- Cleaned up the help text mentioning the Focus Mode toggle.

### Testing
- Built the project with `npm run build` which completed successfully. 
- Started the dev server with `npm run dev` and used browser automation to capture desktop and mobile screenshots for visual verification. 
- No automated test failures were observed; the build and dev steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82c3dac588331918af18a04699cec)