### PR TITLE
Public beta hardening release candidate

### DIFF
--- a/Sutra.html
+++ b/Sutra.html
@@ -7718,7 +7718,7 @@
             <li><a href="https://platform.openai.com" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">OpenAI</a> — paid (add credit)</li>
             <li><a href="https://console.anthropic.com" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">Anthropic</a> — paid (add credit)</li>
         </ol>
-        <p style="font-size:12px;color:var(--text-secondary);margin-top:8px;">New here? <strong>Groq</strong> or <strong>Gemini</strong> are free and take about two minutes: create an account, open the provider's API-keys page, create a key, then paste it in <strong>Settings ▸ Assistant</strong> and pick a Model ID. Full step-by-step for every provider is in the Sutra Assistant guide (docs/SUTRA_ASSISTANT.md).</p>
+        <p style="font-size:12px;color:var(--text-secondary);margin-top:8px;">New here? <strong>Groq</strong> or <strong>Gemini</strong> are free and take about two minutes: create an account, open the provider's API-keys page, create a key, then paste it in <strong>Settings ▸ Assistant</strong> and pick a Model ID.</p>
         <p style="font-size:12px;color:var(--text-secondary);margin-top:8px;">API keys are stored only in this browser session (sessionStorage) on this device. We do not upload or store your keys.</p>
         <div style="display:flex;justify-content:flex-end;margin-top:8px;"><button onclick="closeChatInfo()">Got it</button></div>
     </div>

--- a/docs/DATA_AND_BACKUPS.md
+++ b/docs/DATA_AND_BACKUPS.md
@@ -271,6 +271,9 @@ one-way door that discards your prior state with no recourse.
 - Assistant **preferences** and **provider/model choices**; the **Assistant
   Activity** log (`sutra:activityLog:v1`, migrated from `flow:activityLog:v1`) —
   not a secret, so it travels.
+- Sanitized visible Assistant chat history, limited to recent user/assistant
+  messages. Hidden prompts, raw reasoning, and provider secrets are stripped
+  before the history is saved or exported.
 
 **Excluded by design:**
 
@@ -280,7 +283,8 @@ one-way door that discards your prior state with no recourse.
   tokens, client secrets, and derived encryption keys** — never exported.
 - **Google Drive sync operational metadata** (`sutra:googleDriveSync:v1`) —
   device-local only.
-- **Conversation history** — session-local.
+- **Raw session conversation cache** (`sessionStorage.chat_history`) — not
+  exported directly. Only the sanitized visible copy above travels.
 - **Regenerable caches** and ephemeral UI state (e.g. scroll position, the
   in-session unlocked-page set) — not exported; locked pages correctly require
   the PIN again after a reload.
@@ -326,7 +330,8 @@ round-trip in a browser.
 | `hwCourses:v2`, `hwTasks:v2` | localStorage | Homework (source of truth) | Mirrored into `appData.homeworkWorkspace` |
 | Curated preference keys | localStorage | Focus timer, streak settings, provider/model choices, Assistant Activity | Embedded in exports |
 | `sutra:googleDriveSync:v1` | localStorage | Non-secret Drive sync metadata | Device-local only; not exported |
-| API keys, chat history | sessionStorage | Secrets + conversation | Never persisted, never exported |
+| Sanitized Assistant chat history | IndexedDB / `.sutra` settings | Recent visible conversation only | Persisted and exported so chat restores without an API key |
+| API keys and raw chat session cache | sessionStorage | Secrets + in-session mirror | API keys never persist/export; raw cache is not exported directly |
 
 For the authoritative, line-referenced behavior and the verification scripts,
 read [`sutra-save-systems-audit.md`](./sutra-save-systems-audit.md).

--- a/docs/PRIVACY_AND_LOCAL_FIRST.md
+++ b/docs/PRIVACY_AND_LOCAL_FIRST.md
@@ -49,7 +49,10 @@ Some things are deliberately kept out of every backup file:
   you export your workspace, the exporter actively **redacts** any nested
   secret-shaped field (keys, tokens, passwords) so credentials cannot ride along
   by accident.
-- **Conversation history** with the Assistant is session-local and not exported.
+- **Raw Assistant session cache** is not exported directly. Sutra does persist a
+  sanitized visible chat history so recent conversations can reload and restore
+  from `.sutra`; hidden prompts, raw reasoning, and provider secrets are stripped
+  first.
 - **Backup passwords, Google Drive sync passwords, OAuth access tokens, refresh
   tokens, client secrets, and derived encryption keys** are never exported.
 - **Google Drive sync metadata** (`sutra:googleDriveSync:v1`) is device-local
@@ -68,8 +71,10 @@ Sutra uses your browser's local storage facilities:
 - **localStorage** holds homework data, a small set of preferences, and the
   Storage Health/save-failure banner state needed to warn you after a reload if
   IndexedDB could not confirm a save.
-- **sessionStorage** holds only session-scoped, never-persisted items -
-  principally your AI API keys and chat history.
+- **sessionStorage** holds session-scoped items - principally your AI API keys
+  and an in-session mirror of chat history. API keys stay session-only and are
+  never exported; sanitized visible chat history is also stored in the workspace
+  so it can reload and restore from backups.
 
 Some of these stores carry **legacy-named compatibility identifiers** - for
 example the workspace database is named `noteflow_atelier_db` and the
@@ -160,8 +165,10 @@ local storage:
    (`noteflow_atelier_db`, `noteflow_attachments_db`) and the localStorage keys.
 3. Reload. Sutra comes back **empty / at defaults**, as a fresh workspace.
 
-Session-only items (API keys, chat history) also clear automatically when the
-browser session ends.
+Session-only API keys clear automatically when the browser session ends. Recent
+visible Assistant chat can remain in the workspace and in backups after secrets
+and hidden reasoning are stripped, so restored chats are readable without
+re-entering an API key.
 
 > Tip: if Sutra ever misbehaves and you only want to disable custom CSS and
 > plugins **without** deleting anything, use **Safe Mode** instead of wiping -

--- a/docs/PUBLIC_BETA_RC_REPORT.md
+++ b/docs/PUBLIC_BETA_RC_REPORT.md
@@ -1,0 +1,107 @@
+# Sutra Public-Beta Release-Candidate Report
+
+Date: 2026-06-07
+Branch: `release/public-beta-hardening`
+
+## Executive Summary
+
+This branch hardens the Sutra Assistant transcript boundary, preserves sanitized
+visible chat history across reload and backup restore, updates privacy/backup
+documentation to match that behavior, and fixes a Windows path bug in the brand
+asset release check.
+
+The staged production artifact is ready for local limited-beta review, but this
+is **not a fully verified broad public release**. The supplied Stage 2 audit
+password file was empty, so correct-password validation of the provided
+`sutra-audit-export-*.sutra` artifacts could not be completed.
+
+## Security Verdict
+
+- Passwordless Stage 1 audit found no recoverable plaintext or sentinel strings
+  in the supplied `.sutra` artifacts.
+- Stage 1 found a serious supplied-artifact issue: both provided exports were
+  byte-identical, including salt, IV, and ciphertext.
+- Stage 2 for the supplied artifacts is **not verified** because the local
+  disposable password file was empty after Stage 1.
+- Generated-fixture browser tests verify current production code produces
+  randomized encrypted exports, rejects wrong passwords, rejects tampering
+  without local state mutation, and keeps API keys out of storage and exports.
+
+Direct stolen-file answer: **uncertain for the supplied artifacts** because the
+correct password was unavailable and the pair was byte-identical. For the current
+tested implementation, evidence supports password-protected AES-GCM envelopes
+with no plaintext workspace recovery without the password.
+
+## Changes Made
+
+- Removed visible Assistant reasoning/`<think>` rendering.
+- Added Assistant transcript sanitization for closed and unclosed reasoning tags
+  and reasoning fences.
+- Removed raw provider JSON fallback rendering so unsupported provider response
+  shapes do not expose hidden fields.
+- Prevented Assistant action buttons from falling back to unsanitized raw reply
+  text.
+- Persisted only sanitized visible Assistant chat history in workspace settings,
+  capped to recent messages, while keeping provider API keys session-only.
+- Updated backup/privacy/Assistant docs to distinguish sanitized visible chats
+  from API keys and raw session mirrors.
+- Removed a visible `docs/SUTRA_ASSISTANT.md` path from shipped app copy because
+  docs are intentionally excluded from the deploy artifact.
+- Fixed `scripts/sutra-brand-assets-check.mjs` Windows path handling by using
+  `fileURLToPath()`.
+
+## Evidence
+
+Stage 1/2 artifacts were kept outside the repo under `../security-artifacts/` and
+were not staged or committed.
+
+Password-file handling:
+- `../security-artifacts.sutra-audit-password.txt`: removed
+- `../security-artifacts/.sutra-audit-password.txt`: absent
+- Password printed or stored in repo: no
+
+Automated checks:
+- Local static/pre-beta suite: passed
+  - syntax, smoke, round-trip, version history, rebrand, compatibility, CSP,
+    persistence health, modal accessibility, network/CDN, encoding, responsive,
+    brand assets, document backgrounds
+- Full Chromium E2E: `62 passed`
+- Targeted WebKit release smoke: `4 passed`
+  - startup/no third-party/CSP
+  - emergency `.sutra` export
+  - corrupt `.sutra` import refusal
+  - Assistant reasoning/storage/export sanitization
+- Deploy artifact:
+  - `build-deploy-artifact.mjs`: `.deploy/`, 70 files, 9.69 MB
+  - `sutra-deploy-artifact-check.mjs`: passed
+  - local staged live smoke: passed, no exposed `/tests`, `/scripts`,
+    `package.json`, or `.github`, clean headless boot, no unexpected startup
+    third-party requests
+- Heavy workspace benchmark:
+  - 1000 notes, 400 tasks
+  - load 1462 ms, render 366 ms, serialize 4 ms, save 2385 ms
+  - `.sutra` export 285 ms, import 3287 ms, JSON size 3.73 MB
+
+## Known Limitations and Deferred Work
+
+- Supplied `.sutra` Stage 2 correct-password restore could not be verified
+  because the password file was empty.
+- The two supplied `.sutra` files are byte-identical; rerun the disposable audit
+  with a fresh non-empty password and independently generated export pair.
+- Full WebKit matrix timed out locally after 30 minutes; the bounded WebKit
+  release smoke passed.
+- Firefox was not installed locally; adding it requires a network browser
+  download.
+- Live Google OAuth, physical iOS/Android file picker behavior, real production
+  deployment smoke, social preview validation, and real post-deploy checks were
+  not run because this branch was not deployed and no production secrets were
+  used.
+- Broader product-polish items from the master prompt that are not covered by
+  this branch should remain deferred unless separately verified.
+
+## Release Call
+
+This branch is suitable for a **draft PR and limited local beta review** with the
+evidence above. Broader public release remains blocked until the supplied
+password-based `.sutra` audit is rerun successfully and the remaining manual and
+cross-browser checks are completed.

--- a/docs/SUTRA_ASSISTANT.md
+++ b/docs/SUTRA_ASSISTANT.md
@@ -107,8 +107,10 @@ The Assistant has two memory modes:
   conversation so you can follow up naturally ("now make it shorter," "do the
   same for chapter 3").
 
-Conversation history is held for the session and is **not** written into your
-exported backups (see §8).
+Recent visible conversation history is sanitized, saved with the workspace, and
+written into backups so chats can reload and restore from `.sutra`. Hidden
+prompts, raw reasoning, and provider secrets are stripped before that history is
+stored. API keys remain session-only and are not exported.
 
 ### Suggested Prompts
 
@@ -282,7 +284,8 @@ balance.
 - **AI requests go browser → the provider you chose**, and nowhere else. Sutra
   operates no model servers and no relay.
 - **API keys never leave the session** and are never exported.
-- **Conversation history** is held for the session and is **not** exported.
+- **Visible conversation history** is sanitized and exported so recent chats can
+  reload and restore; hidden prompts, raw reasoning, and API keys are excluded.
 - **What is sent to the provider** is your message plus the context permitted by
   your **Workspace Access** level (and your current selection, if any) — not your
   whole workspace by default.

--- a/docs/sutra-save-systems-audit.md
+++ b/docs/sutra-save-systems-audit.md
@@ -181,9 +181,10 @@ Legend: **R** = survives refresh / IndexedDB reload · **X** = in export payload
 | Sutra Assistant | preferences (enabled, contextDepth, chatMemoryMode, local endpoint config) | `appData.settings.preferences.assistant` | ✓ | ✓ | ✓ | PASS |
 | Sutra Assistant | provider/model choices | localStorage `chat_provider`/`chat_model_by_provider`/`chat_custom_model_by_provider` | ✓ | ✓ | ✓ | PASS |
 | Sutra Assistant | activity log | localStorage `flow:activityLog:v1` | ✓ | ✓ | ✓ | PASS |
+| Sutra Assistant | sanitized visible chat history | `appData.settings.assistantChatHistory` + session mirror | ✓ | ✓ | ✓ | PASS |
 | Sutra Assistant–created items | notes/tasks/timeline/homework/review decks | flow into the normal stores above | ✓ | ✓ | ✓ | PASS |
 | AI secrets | provider API keys | **sessionStorage only** | ✗ (by design) | ✗ (by design) | ✗ | INTENTIONALLY EXCLUDED |
-| Chat history | conversation | sessionStorage `chat_history` | ✗ (session) | ✗ | ✗ | INTENTIONALLY EXCLUDED |
+| Raw chat session cache | conversation mirror | sessionStorage `chat_history` | ✗ (direct export) | ✗ | ✗ | EXCLUDED; sanitized visible copy travels via settings |
 | Caches | `chat_models_cache_<provider>`, `hwSchemaVersion` | localStorage | ✓ | ✗ (regenerable) | n/a | INTENTIONALLY EXCLUDED |
 | UI scroll restore | scroll positions | sessionStorage | ✗ (session) | ✗ | ✗ | INTENTIONALLY EXCLUDED |
 
@@ -213,7 +214,7 @@ the export. They are NOT separately exported and do not need to be._
 **localStorage — cache/marker (intentionally not exported)**
 `chat_models_cache_<provider>`, `hwSchemaVersion`.
 
-**sessionStorage — never persisted, never exported (secrets/ephemeral)**
+**sessionStorage — never directly exported (secrets/ephemeral mirrors)**
 `groq_api_key`, `openai_api_key`, `anthropic_api_key`, `gemini_api_key`,
 `openrouter_api_key`, `local_api_key`, `chat_history`,
 `noteflow_ui_scroll_state_v1`.
@@ -363,7 +364,10 @@ File: `scripts/sutra-persistence-qa.js` (new)
 ## 20. Intentionally excluded data
 - **AI provider API keys / secrets** — sessionStorage only; excluded for privacy.
   Re-enter after import. (Provider/model **choices** are exported.)
-- **Chat history** (`chat_history`) — session-local by product design.
+- **Raw chat session cache** (`chat_history`) — not directly exported; the
+  sanitized visible Assistant history travels via `settings.assistantChatHistory`
+  so chats can reload and restore without exposing hidden prompts, raw
+  reasoning, or API keys.
 - **Regenerable caches** — `chat_models_cache_<provider>`, `hwSchemaVersion`.
 - **Ephemeral UI state** — scroll-restore session, in-session unlocked-page set
   (`unlockedPageIds`): locked pages correctly require PIN re-entry after reload.

--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -118,6 +118,12 @@ mustContain('src/core/app.js', 'wasRetroShellActive', 'applyPresetTheme detects 
 mustContain('src/core/app.js', '!isRetroTheme && wasRetroShellActive', 'applyPresetTheme resets Atelier shell when leaving Retro 95');
 mustContain('src/core/app.js', "chatMemoryMode: 'stateless'", 'assistant chat memory mode default');
 mustContain('src/core/app.js', 'chatMemoryDepth: 10', 'assistant chat memory depth default');
+mustContain('src/core/app.js', 'stripAssistantReasoningText', 'assistant reasoning sanitizer present');
+mustContain('src/core/app.js', '(?:<\\/\\1>|$)', 'assistant reasoning sanitizer strips unclosed XML-style reasoning tags');
+mustContain('src/core/app.js', '(?:```|$)', 'assistant reasoning sanitizer strips unclosed reasoning fences');
+mustContain('src/core/app.js', "const cleanForActions = displayedClean || clean || '';", 'assistant action buttons never fall back to raw unsanitized text');
+mustNotContain('src/core/app.js', 'className = \'assistant-think\'', 'assistant reasoning blocks are not rendered visibly');
+mustNotContain('src/core/app.js', 'clean || text', 'assistant action buttons do not reuse raw assistant text after sanitization');
 
 // JSON export must redact sensitive credentials, like the .atelier export does.
 mustContain('src/core/app.js', 'mode: \'json\', includeSensitiveSettings: false', 'JSON export strips sensitive credentials');

--- a/scripts/sutra-brand-assets-check.mjs
+++ b/scripts/sutra-brand-assets-check.mjs
@@ -18,9 +18,10 @@
 //   - Assistant panel header uses the old Mascot-320.png
 
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = new URL('..', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1');
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const join = (...parts) => resolve(ROOT, ...parts);
 const read = (p) => { try { return readFileSync(join(p), 'utf8'); } catch { return ''; } };
 

--- a/src/core/app.js
+++ b/src/core/app.js
@@ -3102,6 +3102,7 @@ function populateProgressDashboard() {
                         visionCapable: false
                     }
                 },
+                assistantChatHistory: [],
                 studentPreferences: {
                     schoolStartHour: 8,
                     schoolEndHour: 15,
@@ -5844,6 +5845,7 @@ function populateProgressDashboard() {
                     || merged.settings.customShortcuts
             );
             merged.settings.enabledViews = normalizeEnabledViews(storedSettings.enabledViews);
+            merged.settings.assistantChatHistory = normalizeAssistantChatHistory(storedSettings.assistantChatHistory || merged.settings.assistantChatHistory);
             if (stored && stored.settings && !Object.prototype.hasOwnProperty.call(stored.settings, 'featureSelectionCompleted')) {
                 merged.settings.featureSelectionCompleted = true;
             }
@@ -6176,6 +6178,7 @@ function populateProgressDashboard() {
             );
             appSettings.atelierTheme = normalizeAtelierThemeName(appSettings.atelierTheme);
             appSettings.enabledViews = normalizeEnabledViews(storedSettings.enabledViews || appSettings.enabledViews);
+            appSettings.assistantChatHistory = normalizeAssistantChatHistory(storedSettings.assistantChatHistory || appSettings.assistantChatHistory);
             if (!Object.prototype.hasOwnProperty.call(storedSettings, 'featureSelectionCompleted')) {
                 appSettings.featureSelectionCompleted = true;
             }
@@ -38869,9 +38872,11 @@ function getActiveEditor() {
         // "move to another device and continue where you left off" portability format.
         //
         // Intentionally NOT exported (kept device-local only):
-        //   - sessionStorage entries (chat history, AI provider API keys like
+        //   - sessionStorage entries (AI provider API keys like
         //     groq_api_key/openai_api_key/anthropic_api_key/gemini_api_key/openrouter_api_key,
         //     UI scroll-restore session)
+        //   - raw chat_history sessionStorage (sanitized visible Assistant chats travel
+        //     through appData.settings.assistantChatHistory instead)
         //   - OAuth tokens (managed in-memory by auth flows)
         //   - hwSchemaVersion (schema marker, regenerated automatically)
         //   - chat_models_cache_<provider> (regenerable cache)
@@ -41650,6 +41655,7 @@ ${buildPdfExportBodyHtml(title, bodyHtml)}
             appSettings.motionEnabled = appSettings.preferences.appearance.motionIntensity !== 'off';
             appSettings.customShortcuts = normalizeCustomShortcuts(importedSettingsSource.customShortcuts || importedSettingsSource.shortcutLinks);
             appSettings.enabledViews = normalizeEnabledViews(importedSettingsSource.enabledViews || appSettings.enabledViews);
+            appSettings.assistantChatHistory = normalizeAssistantChatHistory(importedSettingsSource.assistantChatHistory || appSettings.assistantChatHistory);
             if (!Object.prototype.hasOwnProperty.call(importedSettingsSource, 'featureSelectionCompleted')) {
                 appSettings.featureSelectionCompleted = true;
             }
@@ -49074,11 +49080,43 @@ ${cspMeta}
             return out;
         }
 
-        // Conversation/history storage (for summarization and continuation)
+        // Conversation/history storage (visible chat only; secrets and hidden
+        // prompts/reasoning are stripped before rendering, persistence, or export).
         const editorEl = document.getElementById('editor');
+        const ASSISTANT_CHAT_HISTORY_LIMIT = 100;
         let convo = [];
 
+        function stripAssistantReasoningText(raw) {
+            let text = String(raw == null ? '' : raw);
+            text = text.replace(/<(think|thinking|reasoning|analysis)\b[^>]*>[\s\S]*?(?:<\/\1>|$)/gi, '');
+            text = text.replace(/```(?:think|thinking|reasoning|analysis)\s*[\s\S]*?(?:```|$)/gi, '');
+            text = text.replace(/^\s*(?:system|developer|assistant_internal|hidden prompt)\s*:\s*[\s\S]*?(?=\n{2,}|$)/gim, '');
+            return text.replace(/\n{3,}/g, '\n\n').trim();
+        }
+
+        function sanitizeAssistantMessageForStorage(role, content) {
+            const safeRole = String(role || '').toLowerCase() === 'assistant' ? 'assistant' : 'user';
+            const raw = String(content == null ? '' : content);
+            const clean = safeRole === 'assistant' ? stripAssistantReasoningText(raw) : raw.trim();
+            return clean ? { role: safeRole, content: clean } : null;
+        }
+
+        function normalizeAssistantChatHistory(raw) {
+            const source = Array.isArray(raw) ? raw : [];
+            return source
+                .map(entry => sanitizeAssistantMessageForStorage(entry && entry.role, entry && entry.content))
+                .filter(Boolean)
+                .slice(-ASSISTANT_CHAT_HISTORY_LIMIT);
+        }
+
+        function persistAssistantChatHistory() {
+            if (!appSettings || typeof appSettings !== 'object') return;
+            appSettings.assistantChatHistory = normalizeAssistantChatHistory(convo);
+            try { persistAppData(); } catch (error) { console.warn('Unable to persist assistant chat history', error); }
+        }
+
         function saveConvo() {
+            convo = normalizeAssistantChatHistory(convo);
             try {
                 sessionStorage.setItem('chat_history', JSON.stringify(convo));
             } catch (error) {
@@ -49089,20 +49127,31 @@ ${cspMeta}
             } catch (error) {
                 console.warn('Unable to clear legacy chat history from local storage', error);
             }
+            persistAssistantChatHistory();
         }
 
         function loadConvo() {
             try {
+                const fromSettings = appSettings && Array.isArray(appSettings.assistantChatHistory)
+                    ? normalizeAssistantChatHistory(appSettings.assistantChatHistory)
+                    : [];
+                if (fromSettings.length) {
+                    convo = fromSettings;
+                    try { sessionStorage.setItem('chat_history', JSON.stringify(convo)); } catch (err) { console.warn('Unable to mirror assistant chat history into session storage', err); }
+                    return;
+                }
                 const fromSession = sessionStorage.getItem('chat_history');
                 if (fromSession) {
-                    convo = JSON.parse(fromSession || '[]');
+                    convo = normalizeAssistantChatHistory(JSON.parse(fromSession || '[]'));
+                    persistAssistantChatHistory();
                     return;
                 }
                 const legacy = localStorage.getItem('chat_history');
                 if (legacy) {
-                    convo = JSON.parse(legacy || '[]');
+                    convo = normalizeAssistantChatHistory(JSON.parse(legacy || '[]'));
                     try { sessionStorage.setItem('chat_history', JSON.stringify(convo)); } catch (err) { console.warn('Unable to migrate chat history into session storage', err); }
                     try { localStorage.removeItem('chat_history'); } catch (err) { console.warn('Unable to clear legacy chat history from local storage', err); }
+                    persistAssistantChatHistory();
                     return;
                 }
                 convo = [];
@@ -49161,24 +49210,13 @@ ${cspMeta}
         }
 
         // appendMessage now adds an insert button for assistant messages
-        function splitThinkBlocks(raw) {
-            const src = String(raw || '');
-            const re = /<(think|thinking)>([\s\S]*?)<\/\1>/gi;
-            const thoughts = [];
-            const clean = src.replace(re, (_, _tag, body) => {
-                thoughts.push(String(body || '').trim());
-                return '';
-            }).replace(/\n{3,}/g, '\n\n').trim();
-            return { thoughts, clean };
-        }
-
         function appendMessage(role, text) {
             const wrap = document.createElement('div');
             wrap.className = 'chatbot-msg ' + (role === 'user' ? 'user' : 'assistant');
             const bubble = document.createElement('div');
             bubble.className = 'bubble';
             if (role === 'assistant') {
-                const { thoughts, clean } = splitThinkBlocks(text);
+                const clean = stripAssistantReasoningText(text);
                 // Sutra Assistant: extract action proposals before rendering, so the user
                 // never sees the raw JSON fenced block in the reply bubble.
                 let flowResult = null;
@@ -49192,19 +49230,6 @@ ${cspMeta}
                     }
                 } catch (e) { /* fall through to plain render */ }
 
-                thoughts.forEach((thought, idx) => {
-                    if (!thought) return;
-                    const details = document.createElement('details');
-                    details.className = 'assistant-think';
-                    const summary = document.createElement('summary');
-                    summary.textContent = thoughts.length > 1 ? `Thinking ${idx + 1}` : 'Thinking';
-                    const body = document.createElement('div');
-                    body.className = 'think-body';
-                    body.textContent = thought;
-                    details.appendChild(summary);
-                    details.appendChild(body);
-                    bubble.appendChild(details);
-                });
                 const answerHost = document.createElement('div');
                 answerHost.innerHTML = renderMarkdown(displayedClean || '');
                 bubble.appendChild(answerHost);
@@ -49220,7 +49245,7 @@ ${cspMeta}
                 const actions = document.createElement('div');
                 actions.className = 'assistant-actions';
                 const allowInsert = getWorkspacePreference('assistant.selectedTextActions', true) !== false;
-                const cleanForActions = displayedClean || clean || text;
+                const cleanForActions = displayedClean || clean || '';
                 if (allowInsert) {
                     const insertBtn = document.createElement('button');
                     insertBtn.type = 'button';
@@ -49294,10 +49319,11 @@ ${cspMeta}
                 if (typeof obj.error === 'string') return obj.error;
                 if (obj.error.message) return obj.error.message;
             }
-            if (obj.message) return obj.message;
+            if (typeof obj.message === 'string') return obj.message;
             const choice = Array.isArray(obj.choices) ? obj.choices[0] : null;
             if (!choice) return null;
-            const content = choice.message?.content;
+            const message = choice.message && typeof choice.message === 'object' ? choice.message : {};
+            const content = message.content;
             if (typeof content === 'string') return content;
             if (Array.isArray(content)) {
                 return content
@@ -49641,12 +49667,10 @@ ${cspMeta}
                 else if (providerConfig.type === 'gemini') extracted = extractGeminiMessage(data);
                 if (!extracted && data && data.__raw_text) extracted = data.__raw_text;
                 if (!extracted && data && data.error && data.error.message) extracted = data.error.message;
-                if (!extracted && data) {
-                    try { extracted = JSON.stringify(data); } catch (e) { extracted = String(data); }
-                }
                 let assistantText = !resp.ok
                     ? `HTTP ${resp.status} - ${extracted || '(no details)'}`
                     : (extracted || '(no response)');
+                assistantText = stripAssistantReasoningText(assistantText);
 
                 appendMessage('assistant', assistantText);
                 // persist assistant reply into convo
@@ -49657,11 +49681,11 @@ ${cspMeta}
                 const bubbles = messagesEl.querySelectorAll('.chatbot-msg.assistant');
                 if (bubbles.length) bubbles[bubbles.length-1].remove();
                 // Friendly guidance for common CORS/network failure
-                let msg = 'Request failed: ' + err.message;
+                let msg = 'Request failed: ' + (err && err.message ? err.message : String(err));
                 if (err && err.message && err.message.toLowerCase().includes('failed to fetch')) {
                     msg += ' -- this usually means a network issue, blocked API key, or provider CORS policy from browser context.';
                 }
-                appendMessage('assistant', msg);
+                appendMessage('assistant', stripAssistantReasoningText(msg));
             }
         }
 

--- a/tests/e2e/public-beta-hardening.spec.mjs
+++ b/tests/e2e/public-beta-hardening.spec.mjs
@@ -225,3 +225,95 @@ test('reduced-motion startup still renders the workspace', async ({ page }) => {
   await expect(page.locator('.app-container')).toBeVisible();
   await expect(page.locator('#sutraStartupIntro')).toBeHidden({ timeout: 15_000 });
 });
+
+test('Assistant strips reasoning before rendering, storing, and exporting chat history', async ({ page }) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem('openai_api_key', 'sk-test-assistant-secret');
+    localStorage.setItem('sutra_ai_send_ack_v1', '1');
+    localStorage.setItem('chat_provider', 'openai');
+    localStorage.setItem('chat_custom_model_by_provider', JSON.stringify({ openai: 'gpt-test-model' }));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText(text) {
+          window.__copiedAssistantText = String(text || '');
+          return Promise.resolve();
+        }
+      }
+    });
+  });
+  await page.route('https://api.openai.com/v1/chat/completions', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        choices: [{
+          message: {
+            role: 'assistant',
+            content: '<think>SECRET_REASONING_SHOULD_NOT_RENDER</think>\nFinal answer only.\n<thinking>UNCLOSED_REASONING_SHOULD_NOT_RENDER'
+          }
+        }]
+      })
+    });
+  });
+
+  await openApp(page);
+  await page.evaluate(() => {
+    const provider = document.getElementById('chatProviderSelect');
+    const model = document.getElementById('chatCustomModelInput');
+    if (provider) {
+      provider.value = 'openai';
+      provider.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+    if (model) {
+      model.value = 'gpt-test-model';
+      model.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+  await page.evaluate(() => document.getElementById('chatbotBtn').click());
+  await expect(page.locator('#chatbotPanel')).toBeVisible();
+  await page.fill('#chatInput', 'Give me a short answer.');
+  await page.evaluate(() => document.getElementById('chatSendBtn').click());
+
+  await expect(page.locator('#chatbotMessages')).toContainText('Final answer only.');
+  await expect(page.locator('#chatbotMessages')).not.toContainText('SECRET_REASONING_SHOULD_NOT_RENDER');
+  await expect(page.locator('#chatbotMessages')).not.toContainText('UNCLOSED_REASONING_SHOULD_NOT_RENDER');
+  await expect(page.locator('#chatbotMessages')).not.toContainText(/^Thinking$/);
+
+  await page.evaluate(() => {
+    const assistantMessages = document.querySelectorAll('#chatbotMessages .chatbot-msg.assistant');
+    assistantMessages[assistantMessages.length - 1]?.querySelector('.flow-reply-copy')?.click();
+  });
+  const copied = await page.evaluate(() => window.__copiedAssistantText || '');
+  expect(copied).toContain('Final answer only.');
+  expect(copied).not.toContain('SECRET_REASONING_SHOULD_NOT_RENDER');
+  expect(copied).not.toContain('UNCLOSED_REASONING_SHOULD_NOT_RENDER');
+
+  await page.evaluate(() => window.saveWorkspaceLocally());
+  const stored = await page.evaluate(() => {
+    const exported = JSON.stringify(window.serializeWorkspace({ mode: 'json', includeSensitiveSettings: false }));
+    return {
+      sessionHistory: sessionStorage.getItem('chat_history') || '',
+      workspaceHistory: JSON.stringify(window.serializeWorkspace().settings.assistantChatHistory || []),
+      exported
+    };
+  });
+  expect(stored.sessionHistory).toContain('Final answer only.');
+  expect(stored.workspaceHistory).toContain('Final answer only.');
+  expect(stored.sessionHistory).not.toContain('SECRET_REASONING_SHOULD_NOT_RENDER');
+  expect(stored.workspaceHistory).not.toContain('SECRET_REASONING_SHOULD_NOT_RENDER');
+  expect(stored.exported).not.toContain('SECRET_REASONING_SHOULD_NOT_RENDER');
+  expect(stored.sessionHistory).not.toContain('UNCLOSED_REASONING_SHOULD_NOT_RENDER');
+  expect(stored.workspaceHistory).not.toContain('UNCLOSED_REASONING_SHOULD_NOT_RENDER');
+  expect(stored.exported).not.toContain('UNCLOSED_REASONING_SHOULD_NOT_RENDER');
+  expect(stored.exported).not.toContain('sk-test-assistant-secret');
+
+  await page.reload();
+  await page.waitForSelector('#storageOptions', { state: 'attached' });
+  await completeOnboarding(page);
+  await page.evaluate(() => document.getElementById('chatbotBtn').click());
+  await expect(page.locator('#chatbotPanel')).toBeVisible();
+  await expect(page.locator('#chatbotMessages')).toContainText('Final answer only.');
+  await expect(page.locator('#chatbotMessages')).not.toContainText('SECRET_REASONING_SHOULD_NOT_RENDER');
+  await expect(page.locator('#chatbotMessages')).not.toContainText('UNCLOSED_REASONING_SHOULD_NOT_RENDER');
+});


### PR DESCRIPTION
## Executive summary

This draft PR hardens the Sutra Assistant transcript boundary, persists only sanitized visible Assistant chat history for reload/backup restore, fixes a Windows path bug in the brand-asset guard, and adds `docs/PUBLIC_BETA_RC_REPORT.md` with the release-candidate evidence.

Head SHA: `2492207948f1b97956a7cbf88993a5b90e1d8abf`

## Security verdict

- Stage 1 black-box `.sutra` audit was completed before password access and found no recoverable plaintext or sentinel strings.
- Supplied audit exports were byte-identical, including salt, IV, and ciphertext. Treat this as a supplied-artifact duplicate-export randomness blocker.
- Stage 2 for the supplied artifacts is **not verified** because the local disposable password file was empty after Stage 1. The password file has been removed and no security artifacts are staged or committed.
- Generated-fixture browser tests verify current code produces randomized encrypted exports, rejects wrong passwords/tampering without state mutation, and excludes API keys from storage/exports.

Direct stolen-file answer: **uncertain for the supplied artifacts** because correct-password validation could not be run. For the current tested implementation, evidence supports password-protected AES-GCM envelopes with no plaintext recovery without the password.

## Changes

- Remove visible `<think>`/reasoning rendering from Assistant replies.
- Strip closed and unclosed reasoning tags/fences before render, storage, export, and reply actions.
- Remove raw provider JSON fallback rendering.
- Store sanitized visible Assistant chat history in workspace settings; keep API keys session-only.
- Update privacy/backup/Assistant docs to match the tested persistence model.
- Remove a visible non-shipped docs path from app copy.
- Fix Windows path handling in `scripts/sutra-brand-assets-check.mjs`.

## Verification

- Static/pre-beta suite: syntax, smoke, round-trip, version history, rebrand, compatibility, CSP, persistence health, modal accessibility, network/CDN, encoding, responsive, brand assets, document backgrounds: passed.
- Full Chromium E2E: `62 passed`.
- Targeted WebKit release smoke: `4 passed`.
- Deploy artifact build/check: `.deploy/`, 70 files, 9.69 MB, check passed.
- Local staged live smoke: passed; no exposed `/tests`, `/scripts`, `package.json`, `.github`; clean headless boot; no unexpected startup third-party requests.
- Heavy workspace benchmark: 1000 notes/400 tasks; load 1462 ms, save 2385 ms, `.sutra` export 285 ms, import 3287 ms.

## Remaining blockers

- Re-run Stage 2 with a non-empty disposable password file or a fresh audit pair.
- Full WebKit matrix timed out locally after 30 minutes; bounded WebKit release smoke passed.
- Firefox browser was not installed locally.
- No production deploy was performed, and live OAuth/mobile/post-deploy/manual checks remain unclaimed.

Do not merge until the Stage 2 supplied-artifact blocker is resolved or explicitly accepted for limited beta scope.