### PR TITLE
Show enabled workspace tabs on desktop

### DIFF
--- a/Sutra.html
+++ b/Sutra.html
@@ -7768,6 +7768,7 @@
     <script src="src/features/workspace/contextual-shell.js?v=20260808-contextual-ui10"></script>
 <script src="src/features/workspace/startup-default-bridge.js?v=20260809-audit3"></script>
     <script src="src/core/app.js?v=20260811-storage-cas3"></script>
+    <script src="src/features/workspace/primary-nav-visibility.js?v=20260812-primarynav3"></script>
     <script src="src/features/workspace/theme-presets-refresh.js?v=20260810-peach-theme1"></script>
     <script src="src/features/workspace/help-docs-refresh.js?v=20260809-helpdocs1"></script>
     <!-- Small post-load UX repairs from the audited shell; core state remains canonical. -->

--- a/scripts/cache-stamp-lock.json
+++ b/scripts/cache-stamp-lock.json
@@ -295,6 +295,10 @@
     "stamp": "20260807-icsnotifications1",
     "hash": "c3b9273c2a3e5c3e"
   },
+  "src/features/workspace/primary-nav-visibility.js": {
+    "stamp": "20260812-primarynav3",
+    "hash": "5df68eb2abb8212c"
+  },
   "src/features/workspace/share-target.js": {
     "stamp": "20260712-share1",
     "hash": "76654a6d7b2c8d91"

--- a/src/features/workspace/primary-nav-visibility.js
+++ b/src/features/workspace/primary-nav-visibility.js
@@ -1,0 +1,120 @@
+/*
+ * primary-nav-visibility.js — keep enabled workspace destinations visible on
+ * wide desktop screens while preserving the canonical app.js tab handlers.
+ *
+ * app.js still owns feature gating and the overflow menu. This small bridge
+ * only removes the old progressive-nav presentation on wide desktop so the
+ * existing tabs are available without an extra More click. If the row is too
+ * wide, it becomes horizontally scrollable instead of hiding destinations.
+ */
+(function () {
+  'use strict';
+
+  if (typeof document === 'undefined') return;
+
+  var WIDE_DESKTOP_MIN = 1441;
+  var scheduled = false;
+
+  function isWideDesktop() {
+    return (window.innerWidth || document.documentElement.clientWidth || 0) >= WIDE_DESKTOP_MIN;
+  }
+
+  function restoreDefaultPresentation(row) {
+    if (!row) return;
+    row.style.removeProperty('overflow-x');
+    row.style.removeProperty('overflow-y');
+    row.style.removeProperty('justify-content');
+  }
+
+  function sync() {
+    scheduled = false;
+    var row = document.querySelector('.view-tabs');
+    var wrapper = document.getElementById('moreViewsWrapper');
+    if (!row) return;
+
+    if (!isWideDesktop()) {
+      restoreDefaultPresentation(row);
+      return;
+    }
+
+    Array.prototype.forEach.call(row.children, function (tab) {
+      if (!tab || !tab.classList || !tab.classList.contains('view-tab') || !tab.dataset.view) return;
+      // Respect app.js feature and workspace-mode gating. Those paths use
+      // hidden/aria-hidden; progressive overflow uses only inline display.
+      if (tab.hidden || tab.getAttribute('aria-hidden') === 'true') return;
+      if (tab.style.display === 'none') {
+        tab.style.removeProperty('display');
+        tab.dataset.overflowHidden = 'false';
+      }
+    });
+
+    if (row.style.getPropertyValue('overflow-x') !== 'auto'
+        || row.style.getPropertyPriority('overflow-x') !== 'important') {
+      row.style.setProperty('overflow-x', 'auto', 'important');
+    }
+    if (row.style.getPropertyValue('overflow-y') !== 'hidden'
+        || row.style.getPropertyPriority('overflow-y') !== 'important') {
+      row.style.setProperty('overflow-y', 'hidden', 'important');
+    }
+    if (row.scrollWidth > row.clientWidth + 2) {
+      if (row.style.getPropertyValue('justify-content') !== 'flex-start'
+          || row.style.getPropertyPriority('justify-content') !== 'important') {
+        row.style.setProperty('justify-content', 'flex-start', 'important');
+      }
+    } else {
+      row.style.removeProperty('justify-content');
+    }
+
+    if (wrapper) {
+      if (wrapper.classList.contains('open')) wrapper.classList.remove('open');
+      if (!wrapper.hidden) wrapper.hidden = true;
+      var menu = document.getElementById('moreViewsMenu');
+      var toggle = document.getElementById('moreViewsToggle');
+      if (menu && menu.classList.contains('open')) menu.classList.remove('open');
+      if (toggle && toggle.getAttribute('aria-expanded') !== 'false') {
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    }
+  }
+
+  function schedule() {
+    if (scheduled) return;
+    scheduled = true;
+    window.requestAnimationFrame(sync);
+  }
+
+  function init() {
+    sync();
+    window.addEventListener('resize', schedule);
+    window.addEventListener('noteflow:view-changed', schedule);
+    window.addEventListener('load', schedule);
+
+    // app.js and feature packs can refresh the row after their initial boot
+    // pass. Reconcile those presentation-only changes without touching the
+    // app's feature-gating attributes.
+    var row = document.querySelector('.view-tabs');
+    var wrapper = document.getElementById('moreViewsWrapper');
+    if (row && typeof MutationObserver === 'function') {
+      var observer = new MutationObserver(schedule);
+      observer.observe(row, {
+        attributes: true,
+        attributeFilter: ['style', 'class', 'hidden', 'aria-hidden'],
+        childList: true,
+        subtree: true
+      });
+      if (wrapper) {
+        observer.observe(wrapper, {
+          attributes: true,
+          attributeFilter: ['class', 'hidden', 'style', 'aria-expanded'],
+          subtree: true
+        });
+      }
+    }
+    [0, 100, 500, 1000, 2000].forEach(function (delay) {
+      window.setTimeout(schedule, delay);
+    });
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();


### PR DESCRIPTION
## What changed

- Keeps enabled workspace destinations visible in the primary navigation on wide desktop screens.
- Preserves Sutra's canonical tab handlers, feature gating, and workspace-mode visibility.
- Falls back to the existing overflow navigation at compact desktop widths and preserves the mobile bottom navigation and All sections sheet.
- Registers the new classic script with a cache-busting stamp.

## Why

The top-nav overflow logic hid optional destinations behind **More** even when a wide desktop had enough room. A later startup refresh could also reapply that hidden state after an initial presentation fix.

## User impact

Students can open enabled sections such as College, Life, Business, and Assistant directly from the desktop tab row without an extra More-menu step.

## Validation

- App shell check
- Responsive guard
- Cache-stamp freshness check
- Targeted JavaScript syntax check
- Navigation contract unit tests (3 passed)
- Headless browser verification at 1747px, 1200px, and 390px
- Verified tab click routing, resize restoration, no document overflow, and no page errors