### PR TITLE
fix: recover accidentally emptied workspaces

### DIFF
--- a/Sutra.html
+++ b/Sutra.html
@@ -66,8 +66,8 @@
     <script src="src/domain/icalendar.js?v=20260807-ics3"></script>
     <script src="src/domain/import-engine.js?v=20260807-ics2"></script>
     <script src="src/domain/assistant-permissions.js?v=20260710-assistant-permissions1"></script>
-    <script src="src/persistence/workspace-db.js?v=20260811-storage-cas1"></script>
-    <script src="src/boot/legacy-workspace-migration.js?v=20260817-storage-recovery4"></script>
+    <script src="src/persistence/workspace-db.js?v=20260818-storage-journal4"></script>
+    <script src="src/boot/legacy-workspace-migration.js?v=20260818-storage-journal6"></script>
     <script src="src/persistence/workspace-coordinator.js?v=20260710-coordinator1"></script>
     <script src="src/persistence/revocation-wipe.js?v=20260716-syncwipe1"></script>
     <script src="src/persistence/storage-hygiene.js?v=20260710-hygiene1"></script>
@@ -82,7 +82,7 @@
     <script src="src/sync/sync-store.js?v=20260805-device-session1"></script>
     <script src="src/sync/sync-transport.js?v=20260806-runtime-clean1"></script>
     <script src="src/sync/sync-engine.js?v=20260806-signoutpause1"></script>
-    <script src="src/config/feature-manifest.js?v=20260810-remove-view-actions1"></script>
+    <script src="src/config/feature-manifest.js?v=20260818-cache-refresh1"></script>
     <script src="src/features/feature-registry.js?v=20260709-features1"></script>
     <script src="src/core/startup-health.js?v=20260620-health1"></script>
     <script src="src/state/workspace-normalizers.js?v=20260616-state1"></script>
@@ -109,7 +109,7 @@
     
 <link rel="stylesheet" href="styles/features/startup-intro.css">
     <link rel="stylesheet" href="styles/base/tokens.css?v=20260807-themefocus1">
-    <link rel="stylesheet" href="styles/base/styles.css?v=20260810-updatebanner1">
+    <link rel="stylesheet" href="styles/base/styles.css?v=20260818-cache-refresh1">
     <link rel="stylesheet" href="styles/views/timeline-calendar.css?v=20260808-mobileday1">
     <link rel="stylesheet" href="styles/themes/sutra-pro.css?v=20260807-agentplans1">
     <style id="view-visibility-fallback">

--- a/docs/architecture/persistence-inventory.json
+++ b/docs/architecture/persistence-inventory.json
@@ -214,6 +214,9 @@
   },
   "otherStorageClassifications": {
     "noteflow_atelier_db.workspace.root": { "category": "reconstructed", "reason": "Canonical local working copy; portable descendants are projected according to workspaceFieldClassifications." },
+    "noteflow_atelier_db.workspace.workspace-last-meaningful": { "category": "deviceLocal", "reason": "One-generation local recovery journal written atomically beside the canonical root; never exported or synchronized separately." },
+    "noteflow_atelier_db.workspace.workspace-empty-before-recovery": { "category": "deviceLocal", "reason": "Diagnostic copy of an empty/default root preserved before automatic recovery promotes a richer local candidate." },
+    "noteflow_atelier_db.workspace.workspace-confirmed-root": { "category": "deviceLocal", "reason": "Compact data-presence marker written atomically with canonical commits so a deliberate empty workspace is never mistaken for an unexplained reset." },
     "noteflow_attachments_db.blobs": { "category": "asset", "reason": "Required referenced bytes use assetContracts.courseAttachmentBytes." },
     "sutra_sync_db": { "category": "deviceLocal", "reason": "Account-scoped outboxes, baselines, cursors, tombstones, dedicated conflict-review records/resolved tombstones, device registration state, wrapped keys, and refresh tokens are sync operations, not workspace payload. The browser never opens one account namespace through another account's sync runtime. Conflict resolutions themselves synchronize as encrypted syncAuditLog records." },
     "sutra-drive-sync-keys": { "category": "secret", "reason": "Device-local wrapped/derived Google Drive backup key material." },

--- a/docs/privacy-security/DATA_AND_BACKUPS.md
+++ b/docs/privacy-security/DATA_AND_BACKUPS.md
@@ -26,6 +26,17 @@ fixtures by `npm run check:migrations`.
 - It is hydrated through one merge/normalize path on load and written through one
   debounced save path, with a synchronous flush on page-hide / unload so
   in-progress edits are not lost.
+- Every accepted full-workspace replacement atomically keeps the previous
+  meaningful root at `workspace-last-meaningful`. If startup finds that the
+  canonical `root` is present but empty/default, it restores the local journal
+  before the application can save. A legacy pre-IndexedDB workspace is used only
+  when no meaningful journal exists; record count never outranks recency.
+  The displaced empty root is retained at `workspace-empty-before-recovery` for
+  diagnostics. Each accepted canonical commit also writes a compact
+  `workspace-confirmed-root` data-presence marker in the same transaction, so a
+  deliberately emptied and successfully saved workspace is never replaced by
+  older data.
+  These device-local recovery records are not separate cloud or portable backups.
 
 ### Attachments — binary files (IndexedDB)
 
@@ -506,6 +517,7 @@ round-trip in a browser.
 | Store | Type | Holds | Note |
 |---|---|---|---|
 | `noteflow_atelier_db` (store `workspace`, key `root`) | IndexedDB | The whole `appData` workspace | Legacy-named compatibility identifier |
+| `noteflow_atelier_db` recovery keys | IndexedDB | Last meaningful root, displaced empty candidate, and confirmed-root marker | Device-local recovery journal and commit marker; not exported separately |
 | `noteflow_attachments_db` (store `blobs`) | IndexedDB | Course-file binaries | Legacy-named compatibility identifier |
 | `hwCourses:v2`, `hwTasks:v2` | localStorage | Homework (source of truth) | Mirrored into `appData.homeworkWorkspace` |
 | Curated preference keys | localStorage | Focus timer, streak settings, provider/model choices, Assistant Activity | Embedded in exports |

--- a/scripts/cache-stamp-lock.json
+++ b/scripts/cache-stamp-lock.json
@@ -8,8 +8,8 @@
     "hash": "acc7e41455a80765"
   },
   "src/boot/legacy-workspace-migration.js": {
-    "stamp": "20260817-storage-recovery4",
-    "hash": "34bb121089d40bef"
+    "stamp": "20260818-storage-journal6",
+    "hash": "b4115bed50da8751"
   },
   "src/boot/startup-intro.js": {
     "stamp": "20260809-audit2",
@@ -32,8 +32,8 @@
     "hash": "727e24137be57f62"
   },
   "src/config/feature-manifest.js": {
-    "stamp": "20260810-remove-view-actions1",
-    "hash": "70da95e52c27567d"
+    "stamp": "20260818-cache-refresh1",
+    "hash": "3a84766ba0357058"
   },
   "src/config/sutra-runtime-config.js": {
     "stamp": "20260716-sync6",
@@ -376,8 +376,8 @@
     "hash": "d6fd15f6450e378b"
   },
   "src/persistence/workspace-db.js": {
-    "stamp": "20260811-storage-cas1",
-    "hash": "0bc31c7668272482"
+    "stamp": "20260818-storage-journal4",
+    "hash": "b1f32b92bdbc29e1"
   },
   "src/state/workspace-normalizers.js": {
     "stamp": "20260616-state1",
@@ -436,8 +436,8 @@
     "hash": "4b6ca894ca81bf4f"
   },
   "styles/base/styles.css": {
-    "stamp": "20260810-updatebanner1",
-    "hash": "e4e98bd1ca90fd8b"
+    "stamp": "20260818-cache-refresh1",
+    "hash": "3ce195b7714c5540"
   },
   "styles/base/tokens.css": {
     "stamp": "20260807-themefocus1",
@@ -564,8 +564,8 @@
     "hash": "89b3c42bf00b0453"
   },
   "styles/views/assistant-view.css": {
-    "stamp": "20260808-assistantfab1",
-    "hash": "db216eb4138f5552"
+    "stamp": "20260818-cache-refresh1",
+    "hash": "83547bfefb68adb2"
   },
   "styles/views/contextual-shell.css": {
     "stamp": "20260808-contextual-ui19",

--- a/src/boot/legacy-workspace-migration.js
+++ b/src/boot/legacy-workspace-migration.js
@@ -11,6 +11,66 @@
     const DB_NAME = 'noteflow_atelier_db';
     const STORE_NAME = 'workspace';
     const ROOT_KEY = 'root';
+    const LAST_MEANINGFUL_KEY = 'workspace-last-meaningful';
+    const EMPTY_BEFORE_RECOVERY_KEY = 'workspace-empty-before-recovery';
+    const CONFIRMED_ROOT_KEY = 'workspace-confirmed-root';
+    const KNOWN_WORKSPACE_FIELDS = new Set([
+        'version', 'schema', 'migrationHistory', 'pages', 'spaces', 'tasks', 'taskOrder', 'timeBlocks',
+        'streaks', 'habitTracker', 'collegeTracker', 'academicWorkspace', 'collegeAppWorkspace',
+        'lifeWorkspace', 'businessWorkspace', 'apStudyWorkspace', 'homeworkWorkspace', 'reviewWorkspace',
+        'courseWorkspace', 'schoolSchedule', 'gradePlanner', 'semesterSetup', 'cramSessions', 'trash',
+        'focusSessions', 'energyProfile', 'protectedTime', 'taskDependencies', 'studySessions',
+        'masteryRecords', 'confidenceObservations', 'studentDecisionState', 'assistantPermissions',
+        'assistantMemory', 'syncAuditLog', 'workspaceMeta', 'privateDocuments', 'sharedStudySessions',
+        'operatingManual', 'portfolioWorkspace', 'testingHub', 'focusTemplates', 'customTabs',
+        'splitPaneContexts', 'pinnedPages', 'notificationsState', 'assistantChatHistory', 'settings', 'ui',
+        'globalTheme', 'migrationDiagnostics', 'compatibility', 'unknownWorkspaceFields',
+        'localStorageSnapshot', 'exportedAt'
+    ]);
+    const USER_DATA_PATHS = [
+        'tasks', 'timeBlocks', 'cramSessions', 'trash', 'focusSessions', 'protectedTime',
+        'taskDependencies', 'studySessions', 'masteryRecords', 'confidenceObservations', 'syncAuditLog',
+        'privateDocuments', 'sharedStudySessions', 'customTabs', 'migrationDiagnostics', 'compatibility',
+        'unknownWorkspaceFields', 'assistantMemory.items', 'assistantChatHistory.conversations',
+        'portfolioWorkspace.entries', 'homeworkWorkspace.courses', 'homeworkWorkspace.tasks',
+        'homeworkWorkspace.quarantine', 'reviewWorkspace.decks', 'reviewWorkspace.items',
+        'reviewWorkspace.sessions', 'courseWorkspace.courses', 'courseWorkspace.files',
+        'courseWorkspace.resourceLinks', 'courseWorkspace.relationships', 'habitTracker.habits',
+        'habitTracker.dayStates', 'streaks.dayStates', 'streaks.taskStreaks', 'collegeTracker.research',
+        'collegeTracker.checklist', 'collegeTracker.deadlines', 'collegeTracker.essays',
+        'collegeTracker.prompts', 'academicWorkspace.classes', 'academicWorkspace.assignments',
+        'academicWorkspace.exams', 'academicWorkspace.notesTemplates', 'academicWorkspace.flashcards',
+        'academicWorkspace.extracurriculars', 'collegeAppWorkspace.savedViews',
+        'collegeAppWorkspace.collegeTracker', 'collegeAppWorkspace.essayOrganizer',
+        'collegeAppWorkspace.scoreTracker', 'collegeAppWorkspace.awardsHonors',
+        'collegeAppWorkspace.recommenders', 'collegeAppWorkspace.scholarships',
+        'collegeAppWorkspace.activities', 'collegeAppWorkspace.submissionReadiness',
+        'collegeAppWorkspace.applicationCosts', 'collegeAppWorkspace.financialAidDeadlines',
+        'collegeAppWorkspace.decisionMatrix.colleges', 'collegeAppWorkspace.majorDecisionMatrix.majors',
+        'collegeAppWorkspace.visitTracker.visits', 'lifeWorkspace.goals', 'lifeWorkspace.habits',
+        'lifeWorkspace.habitCompletions', 'lifeWorkspace.habitExcused', 'lifeWorkspace.skills',
+        'lifeWorkspace.fitness', 'lifeWorkspace.calories', 'lifeWorkspace.books', 'lifeWorkspace.spending',
+        'lifeWorkspace.spendingBudgets', 'lifeWorkspace.recurringExpenses', 'lifeWorkspace.journals',
+        'lifeWorkspace.wellness.checkIns', 'lifeWorkspace.wellness.journalEntries',
+        'businessWorkspace.projects', 'businessWorkspace.clients', 'businessWorkspace.invoices',
+        'businessWorkspace.finance', 'businessWorkspace.opportunities', 'businessWorkspace.meetings',
+        'businessWorkspace.proposals', 'businessWorkspace.tasks', 'businessWorkspace.documents',
+        'businessWorkspace.goals', 'businessWorkspace.notes', 'businessWorkspace.activity',
+        'apStudyWorkspace.subjects', 'apStudyWorkspace.units', 'apStudyWorkspace.topics',
+        'apStudyWorkspace.sessions', 'apStudyWorkspace.practiceLogs', 'apStudyWorkspace.activity',
+        'schoolSchedule.schedules', 'schoolSchedule.dayTemplates', 'schoolSchedule.overrides',
+        'schoolSchedule.subscriptions', 'gradePlanner.courses', 'semesterSetup.drafts',
+        'testingHub.custom', 'testingHub.takenExams', 'settings.customShortcuts', 'settings.customThemes',
+        'settings.selectedPagesForTheme', 'settings.recentSearches', 'settings.customization.cssSnippets',
+        'settings.customization.installedPlugins', 'settings.preferences.quotes.customQuotes',
+        'operatingManual.preferredStudyTimes', 'pinnedPages.life', 'pinnedPages.collegeapp',
+        'pinnedPages.notesBySpace'
+    ];
+    const TESTING_PROFILE_KEYS = ['ap', 'sat', 'act', 'mcat', 'gre', 'lsat', 'gmat', 'psat', 'toefl', 'ielts', 'clep', 'ib', 'state'];
+    const TESTING_PROFILE_DATA_KEYS = ['resourceLinks', 'weakAreas', 'practiceTests', 'mistakes', 'tasks'];
+    const BUILT_IN_FOCUS_TEMPLATE_IDS = new Set([
+        'tpl_deep_work', 'tpl_ap_review', 'tpl_homework_sprint', 'tpl_reading_block', 'tpl_project_build', 'tpl_review_focus'
+    ]);
     let migrationPromise = null;
 
     function readLegacyWorkspace() {
@@ -44,15 +104,91 @@
         }
     }
 
+    function valueAtPath(source, path) {
+        return path.split('.').reduce((value, key) => value && typeof value === 'object' ? value[key] : undefined, source);
+    }
+
+    function hasStoredValue(value) {
+        if (Array.isArray(value)) return value.length > 0;
+        if (value && typeof value === 'object') return Object.keys(value).length > 0;
+        return typeof value === 'string' ? value.trim().length > 0 : false;
+    }
+
+    function hasUnknownStoredValue(value) {
+        if (value === undefined || value === null) return false;
+        if (typeof value === 'string') return value.trim().length > 0;
+        if (Array.isArray(value)) return value.length > 0;
+        if (typeof value === 'object') return Object.keys(value).length > 0;
+        // Forward-compatible numeric and boolean fields may be the only copy of
+        // future user state. Treat them conservatively, including 0 and false.
+        return true;
+    }
+
+    function isGeneratedHelpPage(page) {
+        if (!page || typeof page !== 'object') return false;
+        if (page.isSystemPage === true || page.builtInId === 'help-docs' || page.systemRole === 'help-docs') return true;
+        const id = String(page.id || '');
+        return (id === 'help_page' || id.startsWith('help_page_'))
+            && String(page.title || '').trim().toLowerCase() === 'help & docs';
+    }
+
+    function hasUserSpaces(spaces) {
+        if (!Array.isArray(spaces)) return false;
+        return spaces.some(space => space && String(space.id || '') !== 'default');
+    }
+
     function hasMeaningfulData(workspace) {
         if (!workspace || typeof workspace !== 'object') return false;
-        if (Array.isArray(workspace.pages) && workspace.pages.some(page => page && page.isSystemPage !== true && !page.builtInId)) return true;
-        if (Array.isArray(workspace.tasks) && workspace.tasks.length) return true;
-        if (Array.isArray(workspace.timeBlocks) && workspace.timeBlocks.length) return true;
-        const homework = workspace.homeworkWorkspace;
-        if (homework && ((Array.isArray(homework.courses) && homework.courses.length)
-            || (Array.isArray(homework.tasks) && homework.tasks.length))) return true;
+        if (Array.isArray(workspace.pages) && workspace.pages.some(page => page && !isGeneratedHelpPage(page))) return true;
+        if (hasUserSpaces(workspace.spaces)) return true;
+        if (USER_DATA_PATHS.some(path => hasStoredValue(valueAtPath(workspace, path)))) return true;
+        if (typeof valueAtPath(workspace, 'businessWorkspace.quickCapture') === 'string'
+            && valueAtPath(workspace, 'businessWorkspace.quickCapture').trim()) return true;
+        if (TESTING_PROFILE_KEYS.some(profileKey => {
+            const profile = workspace.testingHub && workspace.testingHub[profileKey];
+            if (!profile || typeof profile !== 'object') return false;
+            if (TESTING_PROFILE_DATA_KEYS.some(key => hasStoredValue(profile[key]))) return true;
+            return !!(profile.examDate || profile.targetScore != null || profile.currentScore != null
+                || String(profile.notes || '').trim() || String(profile.resources || '').trim()
+                || String(profile.pacingNotes || '').trim());
+        })) return true;
+        if (Array.isArray(workspace.focusTemplates)
+            && workspace.focusTemplates.some(template => template && !BUILT_IN_FOCUS_TEMPLATE_IDS.has(String(template.id || '')))) return true;
+        if (Object.keys(workspace).some(key => !KNOWN_WORKSPACE_FIELDS.has(key) && hasUnknownStoredValue(workspace[key]))) return true;
         return false;
+    }
+
+    function meaningfulDataScore(workspace) {
+        if (!hasMeaningfulData(workspace)) return 0;
+        const count = value => Array.isArray(value) ? value.length : 0;
+        const userPages = Array.isArray(workspace.pages)
+            ? workspace.pages.filter(page => page && page.isSystemPage !== true && !page.builtInId).length
+            : 0;
+        return (userPages * 10)
+            + (count(workspace.tasks) * 8)
+            + (count(workspace.homeworkWorkspace && workspace.homeworkWorkspace.tasks) * 8)
+            + (count(workspace.timeBlocks) * 4)
+            + (count(workspace.reviewWorkspace && workspace.reviewWorkspace.items) * 3)
+            + (count(workspace.reviewWorkspace && workspace.reviewWorkspace.decks) * 5)
+            + (count(workspace.courseWorkspace && workspace.courseWorkspace.courses) * 5)
+            + (count(workspace.courseWorkspace && workspace.courseWorkspace.files) * 2)
+            + count(workspace.focusSessions)
+            + count(workspace.cramSessions)
+            + 1;
+    }
+
+    function chooseRecoveryCandidate(journal, legacy) {
+        // The journal is the immediately previous confirmed canonical root.
+        // A legacy localStorage copy can be much older, so record count must
+        // never let it outrank the journal.
+        if (hasMeaningfulData(journal)) return { source: 'journal', workspace: journal };
+        if (hasMeaningfulData(legacy)) return { source: 'legacy-local-storage', workspace: legacy };
+        return null;
+    }
+
+    function isConfirmedCanonicalRoot(root, marker) {
+        if (!marker || typeof marker !== 'object' || marker.version !== 1) return false;
+        return marker.meaningful === hasMeaningfulData(root);
     }
 
     function healOnboardingState(workspace) {
@@ -89,11 +225,39 @@
         storeName: STORE_NAME,
         version: 7
     });
-    migrationPromise = migrationAdapter.read(ROOT_KEY).then(async root => {
+    migrationPromise = Promise.all([
+        migrationAdapter.read(ROOT_KEY),
+        migrationAdapter.read(LAST_MEANINGFUL_KEY),
+        migrationAdapter.read(CONFIRMED_ROOT_KEY)
+    ]).then(async values => {
+        let root = values[0];
+        const journal = values[1];
+        const confirmedRoot = values[2];
         try {
-            if (!root) {
-                root = readLegacyWorkspace();
-                if (root) await migrationAdapter.write(ROOT_KEY, root);
+            // A matching marker proves the empty/default root was deliberately
+            // accepted by the canonical save path. Do not resurrect older data
+            // over an intentional delete-everything result.
+            if (!hasMeaningfulData(root) && !isConfirmedCanonicalRoot(root, confirmedRoot)) {
+                const recovery = chooseRecoveryCandidate(journal, readLegacyWorkspace());
+                if (recovery) {
+                    // Preserve even the empty/default candidate before replacing it.
+                    // This makes the recovery reversible for diagnostics while the
+                    // richer workspace becomes canonical again.
+                    if (root) await migrationAdapter.write(EMPTY_BEFORE_RECOVERY_KEY, root);
+                    root = recovery.workspace;
+                    await migrationAdapter.write(ROOT_KEY, root);
+                    try {
+                        if (typeof global.SutraReportError === 'function') {
+                            global.SutraReportError('Recovered an empty canonical workspace', {
+                                where: 'legacy-workspace-migration',
+                                source: recovery.source,
+                                score: meaningfulDataScore(root)
+                            }, 'warning');
+                        } else {
+                            console.warn('Recovered an empty canonical workspace from ' + recovery.source + '.');
+                        }
+                    } catch (_) {}
+                }
             }
             const healed = healOnboardingState(root);
             if (healed !== root && healed) await migrationAdapter.write(ROOT_KEY, healed);
@@ -107,7 +271,21 @@
     global.SutraWorkspaceDB = {
         ...originalApi,
         create(options) {
-            const adapter = originalCreate.call(originalApi, options);
+            const requested = options && typeof options === 'object' ? options : {};
+            const isCanonicalWorkspace = String(requested.dbName || '') === DB_NAME
+                && String(requested.storeName || '') === STORE_NAME;
+            const adapterOptions = isCanonicalWorkspace
+                ? {
+                    ...requested,
+                    backupKey: requested.backupKey || LAST_MEANINGFUL_KEY,
+                    shouldBackup: requested.shouldBackup || ((current, _next, key) => String(key) === ROOT_KEY && hasMeaningfulData(current)),
+                    commitKey: requested.commitKey || CONFIRMED_ROOT_KEY,
+                    buildCommit: requested.buildCommit || ((_current, next, key) => String(key) === ROOT_KEY
+                        ? { version: 1, meaningful: hasMeaningfulData(next), confirmedAt: new Date().toISOString() }
+                        : undefined)
+                }
+                : requested;
+            const adapter = originalCreate.call(originalApi, adapterOptions);
             const waitForMigration = () => migrationPromise || Promise.resolve();
             return {
                 ...adapter,

--- a/src/config/asset-manifest.generated.js
+++ b/src/config/asset-manifest.generated.js
@@ -7,13 +7,13 @@
     "./assets/vendor/editor/sutra-editor.min.js?v=3.27.3-b5",
     "./assets/vendor/jszip/jszip.min.js?v=3.10.1",
     "./manifest.webmanifest",
-    "./src/boot/legacy-workspace-migration.js?v=20260817-storage-recovery4",
+    "./src/boot/legacy-workspace-migration.js?v=20260818-storage-journal6",
     "./src/boot/startup-intro.js?v=20260809-audit2",
     "./src/boot/sw-register.js?v=20260709-safeupdate1",
     "./src/compat/legacy-homework.js?v=20260709-compat1",
     "./src/components/icons/icon-paths.js?v=20260810-folder-plus1",
     "./src/components/icons/index.js?v=20260809-audit-icons1",
-    "./src/config/feature-manifest.js?v=20260810-remove-view-actions1",
+    "./src/config/feature-manifest.js?v=20260818-cache-refresh1",
     "./src/config/sutra-runtime-config.js?v=20260716-sync6",
     "./src/core/app.js?v=20260811-storage-cas3",
     "./src/core/dom-safety.js?v=20260613-harden1",
@@ -86,7 +86,7 @@
     "./src/persistence/revocation-wipe.js?v=20260716-syncwipe1",
     "./src/persistence/storage-hygiene.js?v=20260710-hygiene1",
     "./src/persistence/workspace-coordinator.js?v=20260710-coordinator1",
-    "./src/persistence/workspace-db.js?v=20260811-storage-cas1",
+    "./src/persistence/workspace-db.js?v=20260818-storage-journal4",
     "./src/state/workspace-normalizers.js?v=20260616-state1",
     "./src/sync/sync-crypto.js?v=20260716-sync6",
     "./src/sync/sync-diff.js?v=20260716-sync6",
@@ -103,7 +103,7 @@
     "./src/ui/time-enhancer.js",
     "./styles/base/contracts.css?v=20260723-layercontract1",
     "./styles/base/microinteractions.css?v=20260807-cohesion1",
-    "./styles/base/styles.css?v=20260810-updatebanner1",
+    "./styles/base/styles.css?v=20260818-cache-refresh1",
     "./styles/base/tokens.css?v=20260807-themefocus1",
     "./styles/features/academic-command-center.css?v=20260614-acc1",
     "./styles/features/academic-planning.css?v=20260707-batch2",
@@ -165,6 +165,6 @@
     "./src/features/workspace/business-workspace.js?v=20260807-opsqueue1",
     "./styles/features/sutra-assistant-help.css?v=20260729-providerwiz1",
     "./styles/features/sutra-intelligence.css?v=20260610-intel1",
-    "./styles/views/assistant-view.css?v=20260808-assistantfab1"
+    "./styles/views/assistant-view.css?v=20260818-cache-refresh1"
   ]
 }); })(typeof self !== 'undefined' ? self : globalThis);

--- a/src/config/asset-manifest.generated.json
+++ b/src/config/asset-manifest.generated.json
@@ -6,13 +6,13 @@
     "./assets/vendor/editor/sutra-editor.min.js?v=3.27.3-b5",
     "./assets/vendor/jszip/jszip.min.js?v=3.10.1",
     "./manifest.webmanifest",
-    "./src/boot/legacy-workspace-migration.js?v=20260817-storage-recovery4",
+    "./src/boot/legacy-workspace-migration.js?v=20260818-storage-journal6",
     "./src/boot/startup-intro.js?v=20260809-audit2",
     "./src/boot/sw-register.js?v=20260709-safeupdate1",
     "./src/compat/legacy-homework.js?v=20260709-compat1",
     "./src/components/icons/icon-paths.js?v=20260810-folder-plus1",
     "./src/components/icons/index.js?v=20260809-audit-icons1",
-    "./src/config/feature-manifest.js?v=20260810-remove-view-actions1",
+    "./src/config/feature-manifest.js?v=20260818-cache-refresh1",
     "./src/config/sutra-runtime-config.js?v=20260716-sync6",
     "./src/core/app.js?v=20260811-storage-cas3",
     "./src/core/dom-safety.js?v=20260613-harden1",
@@ -85,7 +85,7 @@
     "./src/persistence/revocation-wipe.js?v=20260716-syncwipe1",
     "./src/persistence/storage-hygiene.js?v=20260710-hygiene1",
     "./src/persistence/workspace-coordinator.js?v=20260710-coordinator1",
-    "./src/persistence/workspace-db.js?v=20260811-storage-cas1",
+    "./src/persistence/workspace-db.js?v=20260818-storage-journal4",
     "./src/state/workspace-normalizers.js?v=20260616-state1",
     "./src/sync/sync-crypto.js?v=20260716-sync6",
     "./src/sync/sync-diff.js?v=20260716-sync6",
@@ -102,7 +102,7 @@
     "./src/ui/time-enhancer.js",
     "./styles/base/contracts.css?v=20260723-layercontract1",
     "./styles/base/microinteractions.css?v=20260807-cohesion1",
-    "./styles/base/styles.css?v=20260810-updatebanner1",
+    "./styles/base/styles.css?v=20260818-cache-refresh1",
     "./styles/base/tokens.css?v=20260807-themefocus1",
     "./styles/features/academic-command-center.css?v=20260614-acc1",
     "./styles/features/academic-planning.css?v=20260707-batch2",
@@ -164,6 +164,6 @@
     "./src/features/workspace/business-workspace.js?v=20260807-opsqueue1",
     "./styles/features/sutra-assistant-help.css?v=20260729-providerwiz1",
     "./styles/features/sutra-intelligence.css?v=20260610-intel1",
-    "./styles/views/assistant-view.css?v=20260808-assistantfab1"
+    "./styles/views/assistant-view.css?v=20260818-cache-refresh1"
   ]
 }

--- a/src/config/feature-manifest.js
+++ b/src/config/feature-manifest.js
@@ -32,7 +32,7 @@
       styles: [
         './styles/features/sutra-assistant-help.css?v=20260729-providerwiz1',
         './styles/features/sutra-intelligence.css?v=20260610-intel1',
-        './styles/views/assistant-view.css?v=20260808-assistantfab1'
+        './styles/views/assistant-view.css?v=20260818-cache-refresh1'
       ],
       initialization: 'sutraAssistant.init', teardown: 'sutraAssistant.teardown',
       navigationEntries: ['assistantview'], persistenceNamespace: 'assistantChatHistory',

--- a/src/persistence/workspace-db.js
+++ b/src/persistence/workspace-db.js
@@ -13,6 +13,24 @@
     var dbName = String(config.dbName || 'sutra_workspace_db');
     var version = Math.max(1, Math.floor(Number(config.version) || 1));
     var storeName = String(config.storeName || 'workspace');
+    // Optional one-generation journal for callers that store a complete record
+    // under one key. The backup and replacement are written in the SAME
+    // transaction, so a crash can never leave a half-updated journal pair.
+    var backupKey = config.backupKey === null || config.backupKey === undefined
+      ? ''
+      : String(config.backupKey);
+    var shouldBackup = typeof config.shouldBackup === 'function'
+      ? config.shouldBackup
+      : function (current) { return current !== null && current !== undefined; };
+    // Optional compact marker written in the same transaction as the root.
+    // It lets callers distinguish an accepted canonical write from a later
+    // out-of-band overwrite without storing a second copy of the new record.
+    var commitKey = config.commitKey === null || config.commitKey === undefined
+      ? ''
+      : String(config.commitKey);
+    var buildCommit = typeof config.buildCommit === 'function'
+      ? config.buildCommit
+      : function () { return undefined; };
     var liveFactory = null;
     var liveDb = null;
     var opening = null;
@@ -167,8 +185,45 @@
             return;
           }
           if (!accepted) return;
+          var store = tx.objectStore(storeName);
+          if (backupKey && backupKey !== String(key)) {
+            var keepCurrent = false;
+            try { keepCurrent = shouldBackup(current, value, key) === true; }
+            catch (error) {
+              predicateError = error;
+              try { tx.abort(); } catch (abortError) { /* fail below */ }
+              fail(error);
+              return;
+            }
+            if (keepCurrent) {
+              var backupRequest;
+              try { backupRequest = store.put(current, backupKey); }
+              catch (error) { fail(error); return; }
+              backupRequest.onerror = function () {
+                fail(backupRequest.error || tx.error || new Error('IndexedDB recovery journal write failed'));
+              };
+            }
+          }
+          if (commitKey && commitKey !== String(key)) {
+            var commitValue;
+            try { commitValue = buildCommit(current, value, key); }
+            catch (error) {
+              predicateError = error;
+              try { tx.abort(); } catch (abortError) { /* fail below */ }
+              fail(error);
+              return;
+            }
+            if (commitValue !== undefined) {
+              var commitRequest;
+              try { commitRequest = store.put(commitValue, commitKey); }
+              catch (error) { fail(error); return; }
+              commitRequest.onerror = function () {
+                fail(commitRequest.error || tx.error || new Error('IndexedDB commit marker write failed'));
+              };
+            }
+          }
           var putRequest;
-          try { putRequest = tx.objectStore(storeName).put(value, key); }
+          try { putRequest = store.put(value, key); }
           catch (error) { fail(error); return; }
           written = true;
           putRequest.onerror = function () {

--- a/sw.js
+++ b/sw.js
@@ -15,10 +15,10 @@
    Bump CACHE_VERSION to invalidate old caches on the next activate.
    ========================================================================== */
 
-importScripts('./src/config/asset-manifest.generated.js?v=20260811-storage-cas3');
+importScripts('./src/config/asset-manifest.generated.js?v=20260818-storage-journal6');
 
 const CACHE_FAMILY = 'sutra-cache-';
-const CACHE_VERSION = `${CACHE_FAMILY}v5-20260811-storage-cas3`;
+const CACHE_VERSION = `${CACHE_FAMILY}v6-20260818-storage-journal6`;
 const ASSET_MANIFEST = self.SUTRA_ASSET_MANIFEST;
 if (!ASSET_MANIFEST || !Array.isArray(ASSET_MANIFEST.critical) || !ASSET_MANIFEST.shell) {
     throw new Error('Sutra service worker asset manifest is missing or invalid.');

--- a/tests/e2e/workspace-empty-root-recovery.spec.mjs
+++ b/tests/e2e/workspace-empty-root-recovery.spec.mjs
@@ -1,0 +1,260 @@
+import { expect, test } from '@playwright/test';
+
+async function openApp(page) {
+  await page.addInitScript(() => {
+    try { sessionStorage.setItem('sutra_intro_played', '1'); } catch (error) {}
+  });
+  await page.goto('/Sutra.html');
+  await page.waitForSelector('#fileInput', { state: 'attached' });
+}
+
+async function leaveAppBeforeDirectStorageSetup(page) {
+  // Direct IndexedDB fixtures must not race Sutra's live autosave queue.
+  await page.goto('/HomePage.html');
+}
+
+async function returnToApp(page) {
+  await page.goto('/Sutra.html');
+  await page.waitForSelector('#fileInput', { state: 'attached' });
+}
+
+async function writeWorkspaceRecord(page, key, value) {
+  await page.evaluate(({ key, value }) => new Promise((resolve, reject) => {
+    const request = indexedDB.open('noteflow_atelier_db', 7);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction('workspace', 'readwrite');
+      tx.objectStore('workspace').put(value, key);
+      tx.oncomplete = () => { db.close(); resolve(); };
+      tx.onerror = () => { db.close(); reject(tx.error); };
+      tx.onabort = () => { db.close(); reject(tx.error); };
+    };
+  }), { key, value });
+}
+
+async function readWorkspaceRecord(page, key) {
+  return page.evaluate(keyToRead => new Promise((resolve, reject) => {
+    const request = indexedDB.open('noteflow_atelier_db', 7);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction('workspace', 'readonly');
+      const get = tx.objectStore('workspace').get(keyToRead);
+      get.onsuccess = () => resolve(get.result || null);
+      get.onerror = () => reject(get.error || tx.error);
+      tx.oncomplete = () => db.close();
+    };
+  }), key);
+}
+
+async function deleteWorkspaceRecord(page, key) {
+  await page.evaluate(keyToDelete => new Promise((resolve, reject) => {
+    const request = indexedDB.open('noteflow_atelier_db', 7);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction('workspace', 'readwrite');
+      tx.objectStore('workspace').delete(keyToDelete);
+      tx.oncomplete = () => { db.close(); resolve(); };
+      tx.onerror = () => { db.close(); reject(tx.error); };
+      tx.onabort = () => { db.close(); reject(tx.error); };
+    };
+  }), key);
+}
+
+function emptyWorkspace() {
+  return {
+    version: 7,
+    pages: [],
+    tasks: [],
+    taskOrder: [],
+    timeBlocks: [],
+    settings: {
+      onboarding: { version: 1, completed: true, skipped: false, migratedFromLegacy: true }
+    }
+  };
+}
+
+function meaningfulWorkspace(pageId, title) {
+  const now = new Date().toISOString();
+  return {
+    version: 7,
+    pages: [{
+      id: pageId,
+      title,
+      type: 'note',
+      content: '<p>Recovery sentinel</p>',
+      blocks: [],
+      createdAt: now,
+      updatedAt: now,
+      spaceId: 'default'
+    }],
+    tasks: [],
+    taskOrder: [],
+    timeBlocks: [],
+    settings: {
+      onboarding: { version: 1, completed: true, skipped: false, migratedFromLegacy: true }
+    }
+  };
+}
+
+test('present-but-empty canonical root recovers the richer legacy workspace', async ({ page }) => {
+  await openApp(page);
+  await leaveAppBeforeDirectStorageSetup(page);
+  await deleteWorkspaceRecord(page, 'workspace-last-meaningful');
+  await deleteWorkspaceRecord(page, 'workspace-confirmed-root');
+  await writeWorkspaceRecord(page, 'root', emptyWorkspace());
+  const legacy = meaningfulWorkspace('legacy-recovery-page', 'Recovered legacy page');
+  await page.evaluate(workspace => {
+    localStorage.setItem('noteflow_atelier_db', JSON.stringify({ appData: workspace }));
+  }, legacy);
+
+  await returnToApp(page);
+
+  const result = await page.evaluate(async () => {
+    const live = window.serializeWorkspace({ mode: 'json', includeSensitiveSettings: false });
+    const preservedEmpty = await new Promise((resolve, reject) => {
+      const request = indexedDB.open('noteflow_atelier_db', 7);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('workspace', 'readonly');
+        const get = tx.objectStore('workspace').get('workspace-empty-before-recovery');
+        get.onsuccess = () => resolve(get.result || null);
+        get.onerror = () => reject(get.error || tx.error);
+        tx.oncomplete = () => db.close();
+      };
+    });
+    return {
+      recovered: live.pages.some(item => item.id === 'legacy-recovery-page'),
+      preservedEmpty: !!preservedEmpty && Array.isArray(preservedEmpty.pages) && preservedEmpty.pages.length === 0
+    };
+  });
+  expect(result).toEqual({ recovered: true, preservedEmpty: true });
+});
+
+test('last meaningful canonical journal restores an accidentally emptied root', async ({ page }) => {
+  await openApp(page);
+  await leaveAppBeforeDirectStorageSetup(page);
+  await writeWorkspaceRecord(page, 'root', meaningfulWorkspace('journal-recovery-page', 'Recovered journal page'));
+  await returnToApp(page);
+
+  // A confirmed save journals the meaningful current root in the same
+  // transaction as the replacement root.
+  await page.evaluate(() => window.saveWorkspaceLocally());
+  await leaveAppBeforeDirectStorageSetup(page);
+  await writeWorkspaceRecord(page, 'root', emptyWorkspace());
+
+  await returnToApp(page);
+  const recovered = await page.evaluate(() => {
+    const live = window.serializeWorkspace({ mode: 'json', includeSensitiveSettings: false });
+    return live.pages.some(item => item.id === 'journal-recovery-page');
+  });
+  expect(recovered).toBe(true);
+});
+
+test('canonical journal outranks a larger but older legacy workspace', async ({ page }) => {
+  await openApp(page);
+  await leaveAppBeforeDirectStorageSetup(page);
+  const journal = meaningfulWorkspace('newer-journal-page', 'Newer journal page');
+  const legacy = meaningfulWorkspace('older-legacy-page-1', 'Older legacy page 1');
+  for (let index = 2; index <= 8; index += 1) {
+    legacy.pages.push(meaningfulWorkspace(`older-legacy-page-${index}`, `Older legacy page ${index}`).pages[0]);
+  }
+  await deleteWorkspaceRecord(page, 'workspace-confirmed-root');
+  await writeWorkspaceRecord(page, 'workspace-last-meaningful', journal);
+  await writeWorkspaceRecord(page, 'root', emptyWorkspace());
+  await page.evaluate(workspace => {
+    localStorage.setItem('noteflow_atelier_db', JSON.stringify({ appData: workspace }));
+  }, legacy);
+
+  await returnToApp(page);
+  const result = await page.evaluate(() => {
+    const live = window.serializeWorkspace({ mode: 'json', includeSensitiveSettings: false });
+    return {
+      journalPresent: live.pages.some(item => item.id === 'newer-journal-page'),
+      legacyPresent: live.pages.some(item => item.id === 'older-legacy-page-1')
+    };
+  });
+  expect(result).toEqual({ journalPresent: true, legacyPresent: false });
+});
+
+test('assistant-only canonical data is not mistaken for an empty workspace', async ({ page }) => {
+  await openApp(page);
+  await leaveAppBeforeDirectStorageSetup(page);
+  const assistantOnly = emptyWorkspace();
+  assistantOnly.assistantChatHistory = {
+    version: 1,
+    currentChatId: 'chat-preserve',
+    legacyMigrationComplete: true,
+    conversations: [{
+      id: 'chat-preserve',
+      title: 'Do not replace me',
+      messages: [{ id: 'message-preserve', role: 'user', content: 'Important study context' }]
+    }]
+  };
+  await writeWorkspaceRecord(page, 'root', assistantOnly);
+  await writeWorkspaceRecord(page, 'workspace-last-meaningful', meaningfulWorkspace('stale-journal-page', 'Stale journal page'));
+
+  await returnToApp(page);
+  const stored = await readWorkspaceRecord(page, 'root');
+  const result = {
+    conversationPresent: stored.assistantChatHistory.conversations.some(item => item.id === 'chat-preserve'),
+    stalePagePresent: stored.pages.some(item => item.id === 'stale-journal-page')
+  };
+  expect(result).toEqual({ conversationPresent: true, stalePagePresent: false });
+});
+
+test('unknown forward-compatible canonical fields prevent automatic replacement', async ({ page }) => {
+  await openApp(page);
+  await leaveAppBeforeDirectStorageSetup(page);
+  const futureWorkspace = emptyWorkspace();
+  futureWorkspace.futureUserCounter = 0;
+  await writeWorkspaceRecord(page, 'root', futureWorkspace);
+  await writeWorkspaceRecord(page, 'workspace-last-meaningful', meaningfulWorkspace('stale-future-journal-page', 'Stale journal page'));
+
+  await returnToApp(page);
+  const stored = await readWorkspaceRecord(page, 'root');
+  expect({
+    futureValue: stored.futureUserCounter,
+    stalePagePresent: stored.pages.some(item => item.id === 'stale-future-journal-page')
+  }).toEqual({ futureValue: 0, stalePagePresent: false });
+});
+
+test('a canonically confirmed empty workspace does not resurrect its journal', async ({ page }) => {
+  await openApp(page);
+  await leaveAppBeforeDirectStorageSetup(page);
+  await writeWorkspaceRecord(page, 'root', meaningfulWorkspace('intentionally-removed-page', 'Remove me intentionally'));
+  await returnToApp(page);
+
+  const committed = await page.evaluate(async next => {
+    const db = window.SutraWorkspaceDB.create({
+      dbName: 'noteflow_atelier_db',
+      storeName: 'workspace',
+      version: 7
+    });
+    try {
+      return await db.writeIf('root', next, current => Array.isArray(current?.pages)
+        && current.pages.some(item => item.id === 'intentionally-removed-page'));
+    } finally {
+      db.close();
+    }
+  }, emptyWorkspace());
+  expect(committed.written).toBe(true);
+
+  await leaveAppBeforeDirectStorageSetup(page);
+  await returnToApp(page);
+  const stored = await readWorkspaceRecord(page, 'root');
+  const journal = await readWorkspaceRecord(page, 'workspace-last-meaningful');
+  const marker = await readWorkspaceRecord(page, 'workspace-confirmed-root');
+  const userPageIds = stored.pages
+    .filter(item => item.id !== 'help_page' && item.systemRole !== 'help-docs' && item.builtInId !== 'help-docs')
+    .map(item => item.id);
+  expect({
+    rootStayedEmpty: userPageIds.length === 0,
+    journalRetained: journal.pages.some(item => item.id === 'intentionally-removed-page'),
+    userPageIds,
+    marker
+  }).toEqual({ rootStayedEmpty: true, journalRetained: true, userPageIds: [], marker: expect.any(Object) });
+});

--- a/tests/unit/workspace-db.test.mjs
+++ b/tests/unit/workspace-db.test.mjs
@@ -109,6 +109,45 @@ test('conditional writes atomically reject a stale workspace base', async () => 
   assert.deepEqual(await first.read('root'), { title: 'newer' });
 });
 
+test('conditional writes journal the last accepted meaningful record atomically', async () => {
+  const fake = makeIndexedDb();
+  const db = create({
+    indexedDB: fake.factory,
+    dbName: 'qa',
+    storeName: 'workspace',
+    backupKey: 'workspace-last-meaningful',
+    shouldBackup: current => Array.isArray(current?.pages) && current.pages.length > 0
+  });
+  const meaningful = { pages: [{ id: 'keep-me' }], tasks: [] };
+  await db.write('root', meaningful);
+
+  const emptied = await db.writeIf('root', { pages: [], tasks: [] }, current => current === meaningful);
+  assert.equal(emptied.written, true);
+  assert.deepEqual(await db.read('workspace-last-meaningful'), meaningful);
+  assert.deepEqual(await db.read('root'), { pages: [], tasks: [] });
+
+  const restored = await db.writeIf('root', { pages: [{ id: 'restored' }], tasks: [] }, current => current?.pages?.length === 0);
+  assert.equal(restored.written, true);
+  assert.deepEqual(await db.read('workspace-last-meaningful'), meaningful, 'an empty current root must not erase the recovery journal');
+});
+
+test('conditional writes persist a compact confirmation marker with the replacement', async () => {
+  const fake = makeIndexedDb();
+  const db = create({
+    indexedDB: fake.factory,
+    dbName: 'qa',
+    storeName: 'workspace',
+    commitKey: 'workspace-confirmed-root',
+    buildCommit: (_current, next, key) => ({ key, empty: next.pages.length === 0 })
+  });
+  await db.write('root', { pages: [{ id: 'before' }] });
+
+  const result = await db.writeIf('root', { pages: [] }, () => true);
+  assert.equal(result.written, true);
+  assert.deepEqual(await db.read('root'), { pages: [] });
+  assert.deepEqual(await db.read('workspace-confirmed-root'), { key: 'root', empty: true });
+});
+
 test('versionchange closes the stale connection and the next operation reopens', async () => {
   const fake = makeIndexedDb();
   const db = create({ indexedDB: fake.factory, dbName: 'qa', storeName: 'workspace' });


### PR DESCRIPTION
## Summary
- keep the last meaningful canonical workspace in an atomic one-generation recovery journal
- recover an unexpectedly empty/default root before application startup can overwrite it
- record confirmed canonical saves so intentional delete-everything results are never resurrected
- classify Assistant-only and forward-compatible unknown data conservatively
- refresh cache stamps and generated runtime manifests so the fix reaches installed/GitHub Pages clients

## Verification
- `npm run test:unit` — 502 passed
- recovery Playwright suite — 6 passed
- persistence, round-trip, service-worker, guardrail, asset-manifest, and cache-stamp checks passed
- production deploy artifact built and validated