### PR TITLE
Stabilize deployment browser fixtures

### DIFF
--- a/tests/e2e/academic-command-center.spec.mjs
+++ b/tests/e2e/academic-command-center.spec.mjs
@@ -1,8 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers/app-ready.mjs';
 
 async function openApp(page) {
   await page.goto('/Sutra.html');
   await page.waitForSelector('#storageOptions', { state: 'attached' });
+  // The academic globals arrive before canonical workspace hydration. Settle
+  // that boundary before hiding onboarding or seeding the command center.
+  await waitForAppReady(page);
   await page.evaluate(() => {
     const overlay = document.getElementById('studentOnboardingOverlay');
     if (overlay) {

--- a/tests/e2e/google-drive-sync.spec.mjs
+++ b/tests/e2e/google-drive-sync.spec.mjs
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers/app-ready.mjs';
 import { installInspectableBlobRequests } from './helpers/inspectable-blob-requests.mjs';
 
 // Network stubs must own requests in every engine, including WebKit. Service
@@ -233,6 +234,10 @@ async function openApp(page, options = {}) {
   const drive = await installDriveMock(page, options);
   await page.goto('/Sutra.html');
   await page.waitForSelector('#fileInput', { state: 'attached' });
+  // The static shell appears before canonical startup settles. Do not seed the
+  // Drive fixture or open its shared password dialog while hydration can still
+  // reset the form fields beneath the test.
+  await waitForAppReady(page);
   await completeOnboarding(page);
   await expect(page.locator('[data-sutra-component="brand-mark"]').first()).toBeVisible();
   await page.evaluate(() => window.SutraDriveSync._resetForTests());

--- a/tests/e2e/google-drive-sync.spec.mjs
+++ b/tests/e2e/google-drive-sync.spec.mjs
@@ -417,6 +417,9 @@ test('a local save during a clean remote pull becomes a conflict instead of bein
   await page.evaluate(() => window.SutraDriveSync.syncNow());
   await page.evaluate(() => window.SutraDriveSync._setMetadataForTests({ localDirty: false }));
   const uploadsBeforePull = drive.uploads.length;
+  await page.evaluate(() => {
+    Object.defineProperty(window.navigator, 'onLine', { configurable: true, get: () => true });
+  });
 
   // Make the mock remote newer before beginning the new cycle. Mutating only
   // when the next list request arrived let an earlier queued cycle consume the

--- a/tests/e2e/google-drive-sync.spec.mjs
+++ b/tests/e2e/google-drive-sync.spec.mjs
@@ -10,7 +10,7 @@ const PASS = 'correct horse battery staple';
 const CLIENT_ID = 'mock-client-id.apps.googleusercontent.com';
 
 async function completeOnboarding(page) {
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     try {
       if (typeof window.markStudentOnboardingCompleted === 'function') {
         window.markStudentOnboardingCompleted(true);
@@ -24,6 +24,7 @@ async function completeOnboarding(page) {
       overlay.style.setProperty('display', 'none', 'important');
       overlay.style.setProperty('pointer-events', 'none', 'important');
     }
+    await window.flowAtelier.flushAppSaveNow('e2e-drive-onboarding-complete');
   });
   await expect(page.locator('#studentOnboardingOverlay')).toBeHidden();
 }

--- a/tests/e2e/google-drive-sync.spec.mjs
+++ b/tests/e2e/google-drive-sync.spec.mjs
@@ -418,28 +418,17 @@ test('a local save during a clean remote pull becomes a conflict instead of bein
   await page.evaluate(() => window.SutraDriveSync._setMetadataForTests({ localDirty: false }));
   const uploadsBeforePull = drive.uploads.length;
 
-  let pullPromise;
-  let pullStarted = false;
-  for (let attempt = 0; attempt < 3 && !pullStarted; attempt += 1) {
-    const mediaStarted = drive.waitForNextMediaGet();
-    if (attempt === 0) {
-      drive.mutateOnNextList(state => {
-        state.files[0].version = '99';
-        state.files[0].modifiedTime = new Date(Date.UTC(2026, 5, 6, 15, 0, 0)).toISOString();
-      });
-    }
-    pullPromise = page.evaluate(() => {
-      window.SutraDriveSync._setMetadataForTests({ localDirty: false });
-      return window.SutraDriveSync.syncNow();
-    });
-    const first = await Promise.race([
-      mediaStarted.then(() => 'media'),
-      pullPromise.then(() => 'cycle')
-    ]);
-    pullStarted = first === 'media';
-    if (!pullStarted) await pullPromise;
-  }
-  expect(pullStarted).toBe(true);
+  // Make the mock remote newer before beginning the new cycle. Mutating only
+  // when the next list request arrived let an earlier queued cycle consume the
+  // mutation, so the asserted pull could legitimately see no remote change.
+  drive.files[0].version = '99';
+  drive.files[0].modifiedTime = new Date(Date.UTC(2026, 5, 6, 15, 0, 0)).toISOString();
+  const mediaStarted = drive.waitForNextMediaGet();
+  const pullPromise = page.evaluate(() => {
+    window.SutraDriveSync._setMetadataForTests({ localDirty: false });
+    return window.SutraDriveSync.syncNow();
+  });
+  await expect(mediaStarted).resolves.toBeGreaterThan(0);
   await seedWorkspace(page, 'MID-PULL-LOCAL');
 
   await expect(pullPromise).resolves.toEqual({ conflict: true });

--- a/tests/e2e/google-drive-sync.spec.mjs
+++ b/tests/e2e/google-drive-sync.spec.mjs
@@ -421,17 +421,28 @@ test('a local save during a clean remote pull becomes a conflict instead of bein
     Object.defineProperty(window.navigator, 'onLine', { configurable: true, get: () => true });
   });
 
-  // Make the mock remote newer before beginning the new cycle. Mutating only
-  // when the next list request arrived let an earlier queued cycle consume the
-  // mutation, so the asserted pull could legitimately see no remote change.
-  drive.files[0].version = '99';
-  drive.files[0].modifiedTime = new Date(Date.UTC(2026, 5, 6, 15, 0, 0)).toISOString();
-  const mediaStarted = drive.waitForNextMediaGet();
-  const pullPromise = page.evaluate(() => {
-    window.SutraDriveSync._setMetadataForTests({ localDirty: false });
-    return window.SutraDriveSync.syncNow();
-  });
-  await expect(mediaStarted).resolves.toBeGreaterThan(0);
+  // A save debounce can still own the first manual call. Make the mocked
+  // remote newer for every attempt so a just-finished stale cycle cannot
+  // consume the only changed version and turn the asserted pull into a clean
+  // no-op.
+  let pullPromise;
+  let pullStarted = false;
+  for (let attempt = 0; attempt < 3 && !pullStarted; attempt += 1) {
+    drive.files[0].version = String(99 + attempt);
+    drive.files[0].modifiedTime = new Date(Date.UTC(2026, 5, 6, 15, attempt, 0)).toISOString();
+    const mediaStarted = drive.waitForNextMediaGet();
+    pullPromise = page.evaluate(() => {
+      window.SutraDriveSync._setMetadataForTests({ localDirty: false });
+      return window.SutraDriveSync.syncNow();
+    });
+    const first = await Promise.race([
+      mediaStarted.then(() => 'media'),
+      pullPromise.then(() => 'cycle')
+    ]);
+    pullStarted = first === 'media';
+    if (!pullStarted) await pullPromise;
+  }
+  expect(pullStarted).toBe(true);
   await seedWorkspace(page, 'MID-PULL-LOCAL');
 
   await expect(pullPromise).resolves.toEqual({ conflict: true });

--- a/tests/e2e/mobile-overlay-layering.spec.mjs
+++ b/tests/e2e/mobile-overlay-layering.spec.mjs
@@ -1,11 +1,15 @@
 import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers/app-ready.mjs';
 
 test.use({ viewport: { width: 390, height: 844 } });
 
 async function openApp(page) {
   await page.goto('/Sutra.html');
   await page.waitForSelector('#sutraBottomNav', { state: 'attached' });
-  await page.evaluate(() => {
+  // The phone shell is present before canonical startup can finish. Settle that
+  // boundary before suppressing onboarding or inserting sidebar test pages.
+  await waitForAppReady(page);
+  await page.evaluate(async () => {
     try {
       if (typeof window.markStudentOnboardingCompleted === 'function') {
         window.markStudentOnboardingCompleted(true);
@@ -19,6 +23,7 @@ async function openApp(page) {
       overlay.style.setProperty('display', 'none', 'important');
       overlay.style.setProperty('pointer-events', 'none', 'important');
     }
+    await window.flowAtelier.flushAppSaveNow('e2e-mobile-overlay-onboarding-complete');
   });
   await expect(page.locator('#sutraBottomNav')).toBeVisible();
 }

--- a/tests/e2e/onboarding-redesign.spec.mjs
+++ b/tests/e2e/onboarding-redesign.spec.mjs
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers/app-ready.mjs';
 
 const PASS = 'correct horse battery staple';
 
@@ -8,10 +9,10 @@ async function openFreshApp(page) {
   });
   await page.goto('/Sutra.html');
   await page.waitForSelector('#fileInput', { state: 'attached' });
-  // Shell markup arrives before the initial canonical write/readback and the
-  // post-hydration onboarding reconciliation. Wait for initApp rather than
-  // racing the durable first-run gate from an attached static element.
-  await page.waitForFunction(() => window.__hwDueDateDelegateBound === true);
+  // Shell markup arrives before the canonical workspace boundary and its
+  // onboarding reconciliation. Use the established readiness seam instead
+  // of treating an unrelated startup delegate as durable readiness.
+  await waitForAppReady(page);
 }
 
 async function completeOnboarding(page) {
@@ -174,10 +175,14 @@ test('Continue later: close overlay and reopen preserves step progress', async (
   const overlay = page.locator('#studentOnboardingOverlay');
   await expect(overlay).not.toBeVisible({ timeout: 3000 });
 
+  // Continue later persists its in-progress step. Do not race that canonical
+  // save with the reload that verifies it.
+  await page.evaluate(() => window.flowAtelier.flushAppSaveNow('e2e-onboarding-continue-later'));
+
   // Reload — dismiss preserves state so onboarding should reappear
   await page.reload();
   await page.waitForSelector('#fileInput', { state: 'attached' });
-  await page.waitForTimeout(1000);
+  await waitForAppReady(page);
 
   // Overlay should reappear since dismiss didn't mark as completed
   const reopen = page.locator('#studentOnboardingOverlay[aria-hidden="false"], #studentOnboardingOverlay:not([aria-hidden])');


### PR DESCRIPTION
Stabilizes the verified-artifact deployment fixtures without changing application, deployment, or Supabase code.

- waits for canonical readiness before academic command-center fixture state is seeded;
- flushes the intentional onboarding Continue later save before reload;
- waits for canonical readiness before Google Drive fixtures seed state or open the shared password dialog;
- flushes the deliberate onboarding-complete save before Drive fixtures mutate state;
- waits for canonical readiness and flushes onboarding completion before mobile-overlay fixtures seed sidebar rows.

These changes fix observed WebKit races where a pending canonical save/hydration could replace fixture state or reset a shared password dialog while a test was interacting with it.

Validation: syntax check passed; affected academic/onboarding WebKit suite passed 19/19; Google Drive restore passed 3 serial WebKit runs; a complete Google Drive WebKit suite passed 9/9 serially; mobile-overlay WebKit suite passed 3/3.